### PR TITLE
Add Max Lending Amount per Asset

### DIFF
--- a/config/networks/ganache/index.js
+++ b/config/networks/ganache/index.js
@@ -4,6 +4,7 @@ module.exports = {
     compound: require('./compound'),
     tokens: require('./tokens'),
     zerocollateral: require('./zerocollateral'),
+    maxLendingAmounts: require('./maxLendingAmounts'),
     maxGasLimit: 6721975,
     toTxUrl: ({ tx }) => {
         return `not-supported-url`;

--- a/config/networks/ganache/maxLendingAmounts.js
+++ b/config/networks/ganache/maxLendingAmounts.js
@@ -1,0 +1,6 @@
+const DEFAULT_MAX_AMOUNT = 1000;
+
+module.exports = {
+    DAI: DEFAULT_MAX_AMOUNT,
+    USDC: DEFAULT_MAX_AMOUNT,
+};

--- a/config/networks/mainnet/index.js
+++ b/config/networks/mainnet/index.js
@@ -3,6 +3,7 @@ module.exports = {
     chainlink: require('./chainlink'),
     compound: require('./compound'),
     dao: require('./dao'),
+    maxLendingAmounts: require('./maxLendingAmounts'),
     maxGasLimit: 3500000,
     toTxUrl: ({ tx }) => {
         return `https://www.etherscan.io/tx/${tx}`;

--- a/config/networks/mainnet/maxLendingAmounts.js
+++ b/config/networks/mainnet/maxLendingAmounts.js
@@ -1,0 +1,6 @@
+const DEFAULT_MAX_AMOUNT = 1000;
+
+module.exports = {
+    DAI: DEFAULT_MAX_AMOUNT,
+    USDC: DEFAULT_MAX_AMOUNT,
+};

--- a/config/networks/rinkeby/index.js
+++ b/config/networks/rinkeby/index.js
@@ -2,6 +2,7 @@ module.exports = {
     network: 'rinkeby',
     chainlink: require('./chainlink'),
     compound: require('./compound'),
+    maxLendingAmounts: require('./maxLendingAmounts'),
     maxGasLimit: 7000000,
     toTxUrl: ({ tx }) => {
         return `https://rinkeby.etherscan.io/tx/${tx}`;

--- a/config/networks/rinkeby/maxLendingAmounts.js
+++ b/config/networks/rinkeby/maxLendingAmounts.js
@@ -1,0 +1,6 @@
+const DEFAULT_MAX_AMOUNT = 1000;
+
+module.exports = {
+    DAI: DEFAULT_MAX_AMOUNT,
+    USDC: DEFAULT_MAX_AMOUNT,
+};

--- a/config/networks/ropsten/index.js
+++ b/config/networks/ropsten/index.js
@@ -5,6 +5,7 @@ module.exports = {
     dao: require('./dao'),
     tokens: require('./tokens'),
     zerocollateral: require('./zerocollateral'),
+    maxLendingAmounts: require('./maxLendingAmounts'),
     maxGasLimit: 7000000,
     toTxUrl: ({ tx }) => {
         return `https://ropsten.etherscan.io/tx/${tx}`;

--- a/config/networks/ropsten/maxLendingAmounts.js
+++ b/config/networks/ropsten/maxLendingAmounts.js
@@ -1,0 +1,6 @@
+const DEFAULT_MAX_AMOUNT = 1000;
+
+module.exports = {
+    DAI: DEFAULT_MAX_AMOUNT,
+    USDC: DEFAULT_MAX_AMOUNT,
+};

--- a/config/networks/soliditycoverage/index.js
+++ b/config/networks/soliditycoverage/index.js
@@ -3,6 +3,7 @@ module.exports = {
     chainlink: require('./chainlink'),
     compound: require('./compound'),
     tokens: require('./tokens'),
+    maxLendingAmounts: require('./maxLendingAmounts'),
     maxGasLimit: 11000000,
     toTxUrl: ({ tx }) => {
         return `not-supported-url`;

--- a/config/networks/soliditycoverage/maxLendingAmounts.js
+++ b/config/networks/soliditycoverage/maxLendingAmounts.js
@@ -1,0 +1,6 @@
+const DEFAULT_MAX_AMOUNT = 1000;
+
+module.exports = {
+    DAI: DEFAULT_MAX_AMOUNT,
+    USDC: DEFAULT_MAX_AMOUNT,
+};

--- a/config/networks/test/index.js
+++ b/config/networks/test/index.js
@@ -3,6 +3,7 @@ module.exports = {
     chainlink: require('./chainlink'),
     compound: require('./compound'),
     tokens: require('./tokens'),
+    maxLendingAmounts: require('./maxLendingAmounts'),
     maxGasLimit: 6000000,
     toTxUrl: ({ tx }) => {
         return `not-supported-url`;

--- a/config/networks/test/maxLendingAmounts.js
+++ b/config/networks/test/maxLendingAmounts.js
@@ -1,0 +1,6 @@
+const DEFAULT_MAX_AMOUNT = 1000;
+
+module.exports = {
+    DAI: DEFAULT_MAX_AMOUNT,
+    USDC: DEFAULT_MAX_AMOUNT,
+};

--- a/contracts/base/EtherCollateralLoans.sol
+++ b/contracts/base/EtherCollateralLoans.sol
@@ -54,7 +54,7 @@ contract EtherCollateralLoans is LoansBase {
         ZeroCollateralCommon.LoanRequest calldata request,
         ZeroCollateralCommon.LoanResponse[] calldata responses,
         uint256 collateralAmount
-    ) external payable isInitialized() whenNotPaused() isBorrower(request.borrower) {
+    ) external payable isInitialized() whenNotPaused() isBorrower(request.borrower) exceedsMaxAmount(request.amount) {
         require(msg.value == collateralAmount, "INCORRECT_ETH_AMOUNT");
 
         uint256 loanID = getAndIncrementLoanID();
@@ -79,15 +79,12 @@ contract EtherCollateralLoans is LoansBase {
 
         borrowerLoans[request.borrower].push(loanID);
 
-        emit LoanTermsSet(
+        _emitLoanTermsSet(
             loanID,
-            request.borrower,
-            request.recipient,
+            request,
             interestRate,
             collateralRatio,
-            maxLoanAmount,
-            request.duration,
-            loans[loanID].termsExpiry
+            maxLoanAmount
         );
         if (msg.value > 0) {
             emit CollateralDeposited(loanID, request.borrower, msg.value);

--- a/contracts/base/EtherCollateralLoans.sol
+++ b/contracts/base/EtherCollateralLoans.sol
@@ -60,7 +60,7 @@ contract EtherCollateralLoans is LoansBase {
         isInitialized()
         whenNotPaused()
         isBorrower(request.borrower)
-        exceedsMaxAmount(request.amount)
+        notExceedsMaxAmount(request.amount)
     {
         require(msg.value == collateralAmount, "INCORRECT_ETH_AMOUNT");
 

--- a/contracts/base/EtherCollateralLoans.sol
+++ b/contracts/base/EtherCollateralLoans.sol
@@ -54,7 +54,14 @@ contract EtherCollateralLoans is LoansBase {
         ZeroCollateralCommon.LoanRequest calldata request,
         ZeroCollateralCommon.LoanResponse[] calldata responses,
         uint256 collateralAmount
-    ) external payable isInitialized() whenNotPaused() isBorrower(request.borrower) exceedsMaxAmount(request.amount) {
+    )
+        external
+        payable
+        isInitialized()
+        whenNotPaused()
+        isBorrower(request.borrower)
+        exceedsMaxAmount(request.amount)
+    {
         require(msg.value == collateralAmount, "INCORRECT_ETH_AMOUNT");
 
         uint256 loanID = getAndIncrementLoanID();
@@ -79,13 +86,7 @@ contract EtherCollateralLoans is LoansBase {
 
         borrowerLoans[request.borrower].push(loanID);
 
-        _emitLoanTermsSet(
-            loanID,
-            request,
-            interestRate,
-            collateralRatio,
-            maxLoanAmount
-        );
+        _emitLoanTermsSet(loanID, request, interestRate, collateralRatio, maxLoanAmount);
         if (msg.value > 0) {
             emit CollateralDeposited(loanID, request.borrower, msg.value);
         }

--- a/contracts/base/LoansBase.sol
+++ b/contracts/base/LoansBase.sol
@@ -71,9 +71,9 @@ contract LoansBase is LoansInterface, Base {
         _;
     }
 
-    modifier exceedsMaxAmount(uint256 amount) {
+    modifier notExceedsMaxAmount(uint256 amount) {
         require(
-            settings.exceedsMaxLendingAmount(lendingPool.lendingToken(), amount),
+            !settings.exceedsMaxLendingAmount(lendingPool.lendingToken(), amount),
             "AMOUNT_EXCEEDS_MAX_AMOUNT"
         );
         _;

--- a/contracts/base/LoansBase.sol
+++ b/contracts/base/LoansBase.sol
@@ -73,10 +73,7 @@ contract LoansBase is LoansInterface, Base {
 
     modifier exceedsMaxAmount(uint256 amount) {
         require(
-            settings.exceedsMaxLendingAmount(
-                lendingPool.lendingToken(),
-                amount
-            ),
+            settings.exceedsMaxLendingAmount(lendingPool.lendingToken(), amount),
             "AMOUNT_EXCEEDS_MAX_AMOUNT"
         );
         _;
@@ -469,7 +466,7 @@ contract LoansBase is LoansInterface, Base {
 
     function _emitLoanTermsSet(
         uint256 loanID,
-         ZeroCollateralCommon.LoanRequest memory request,
+        ZeroCollateralCommon.LoanRequest memory request,
         uint256 interestRate,
         uint256 collateralRatio,
         uint256 maxLoanAmount
@@ -484,5 +481,5 @@ contract LoansBase is LoansInterface, Base {
             request.duration,
             loans[loanID].termsExpiry
         );
-    }    
+    }
 }

--- a/contracts/base/LoansBase.sol
+++ b/contracts/base/LoansBase.sol
@@ -71,6 +71,17 @@ contract LoansBase is LoansInterface, Base {
         _;
     }
 
+    modifier exceedsMaxAmount(uint256 amount) {
+        require(
+            settings.exceedsMaxLendingAmount(
+                lendingPool.lendingToken(),
+                amount
+            ),
+            "AMOUNT_EXCEEDS_MAX_AMOUNT"
+        );
+        _;
+    }
+
     modifier loanTermsSet(uint256 loanID) {
         require(
             loans[loanID].status == ZeroCollateralCommon.LoanStatus.TermsSet,
@@ -455,4 +466,23 @@ contract LoansBase is LoansInterface, Base {
                 liquidated: false
             });
     }
+
+    function _emitLoanTermsSet(
+        uint256 loanID,
+         ZeroCollateralCommon.LoanRequest memory request,
+        uint256 interestRate,
+        uint256 collateralRatio,
+        uint256 maxLoanAmount
+    ) internal {
+        emit LoanTermsSet(
+            loanID,
+            request.borrower,
+            request.recipient,
+            interestRate,
+            collateralRatio,
+            maxLoanAmount,
+            request.duration,
+            loans[loanID].termsExpiry
+        );
+    }    
 }

--- a/contracts/base/Settings.sol
+++ b/contracts/base/Settings.sol
@@ -49,6 +49,14 @@ contract Settings is Pausable, SettingsInterface {
 
     /* State Variables */
 
+    /**
+        It maps a max cap per lending token.
+
+        DAI address => 1000 DAI (max)
+        USDC address => 500 USDC (max)
+     */
+    mapping(address => uint256) public maxLendingAmount;
+
     mapping(address => bool) public lendingPoolPaused;
 
     /**
@@ -253,6 +261,33 @@ contract Settings is Pausable, SettingsInterface {
         lendingPoolPaused[lendingPoolAddress] = false;
 
         emit LendingPoolUnpaused(msg.sender, lendingPoolAddress);
+    }
+
+    function setMaxLendingAmount(address lendingTokenAddress, uint256 newMaxLendingAmount)
+        external
+        onlyPauser()
+    {
+        uint256 oldMaxLendingAmount = maxLendingAmount[lendingTokenAddress];
+        require(oldMaxLendingAmount != newMaxLendingAmount, "NEW_MAX_AMOUNT_REQUIRED");
+        
+        maxLendingAmount[lendingTokenAddress] = newMaxLendingAmount;
+
+        emit MaxLendingAmountUpdated(
+            msg.sender,
+            lendingTokenAddress,
+            oldMaxLendingAmount,
+            newMaxLendingAmount
+        );
+    }
+
+    function getMaxLendingAmount(address lendingTokenAddress) external view returns (uint256) {
+        return maxLendingAmount[lendingTokenAddress];
+    }
+    
+    function exceedsMaxLendingAmount(address lendingTokenAddress, uint256 amount)
+        external view returns (bool)
+    {
+        return amount > maxLendingAmount[lendingTokenAddress];
     }
 
     function isPaused() external view returns (bool) {

--- a/contracts/base/Settings.sol
+++ b/contracts/base/Settings.sol
@@ -269,7 +269,7 @@ contract Settings is Pausable, SettingsInterface {
     {
         uint256 oldMaxLendingAmount = maxLendingAmount[lendingTokenAddress];
         require(oldMaxLendingAmount != newMaxLendingAmount, "NEW_MAX_AMOUNT_REQUIRED");
-        
+
         maxLendingAmount[lendingTokenAddress] = newMaxLendingAmount;
 
         emit MaxLendingAmountUpdated(
@@ -280,12 +280,18 @@ contract Settings is Pausable, SettingsInterface {
         );
     }
 
-    function getMaxLendingAmount(address lendingTokenAddress) external view returns (uint256) {
+    function getMaxLendingAmount(address lendingTokenAddress)
+        external
+        view
+        returns (uint256)
+    {
         return maxLendingAmount[lendingTokenAddress];
     }
-    
+
     function exceedsMaxLendingAmount(address lendingTokenAddress, uint256 amount)
-        external view returns (bool)
+        external
+        view
+        returns (bool)
     {
         return amount > maxLendingAmount[lendingTokenAddress];
     }

--- a/contracts/base/TokenCollateralLoans.sol
+++ b/contracts/base/TokenCollateralLoans.sol
@@ -74,6 +74,7 @@ contract TokenCollateralLoans is LoansBase {
         isInitialized()
         whenNotPaused()
         isBorrower(request.borrower)
+        exceedsMaxAmount(request.amount)
     {
         uint256 loanID = getAndIncrementLoanID();
 
@@ -98,16 +99,14 @@ contract TokenCollateralLoans is LoansBase {
 
         borrowerLoans[request.borrower].push(loanID);
 
-        emit LoanTermsSet(
+        _emitLoanTermsSet(
             loanID,
-            request.borrower,
-            request.recipient,
+            request,
             interestRate,
             collateralRatio,
-            maxLoanAmount,
-            request.duration,
-            loans[loanID].termsExpiry
+            maxLoanAmount
         );
+
         if (collateralAmount > 0) {
             emit CollateralDeposited(loanID, request.borrower, collateralAmount);
         }

--- a/contracts/base/TokenCollateralLoans.sol
+++ b/contracts/base/TokenCollateralLoans.sol
@@ -99,13 +99,7 @@ contract TokenCollateralLoans is LoansBase {
 
         borrowerLoans[request.borrower].push(loanID);
 
-        _emitLoanTermsSet(
-            loanID,
-            request,
-            interestRate,
-            collateralRatio,
-            maxLoanAmount
-        );
+        _emitLoanTermsSet(loanID, request, interestRate, collateralRatio, maxLoanAmount);
 
         if (collateralAmount > 0) {
             emit CollateralDeposited(loanID, request.borrower, collateralAmount);

--- a/contracts/base/TokenCollateralLoans.sol
+++ b/contracts/base/TokenCollateralLoans.sol
@@ -74,7 +74,7 @@ contract TokenCollateralLoans is LoansBase {
         isInitialized()
         whenNotPaused()
         isBorrower(request.borrower)
-        exceedsMaxAmount(request.amount)
+        notExceedsMaxAmount(request.amount)
     {
         uint256 loanID = getAndIncrementLoanID();
 

--- a/contracts/interfaces/SettingsInterface.sol
+++ b/contracts/interfaces/SettingsInterface.sol
@@ -57,9 +57,14 @@ interface SettingsInterface {
 
     function setMaxLendingAmount(address lendingTokenAddress, uint256 newMaxLendingAmount)
         external;
-    
-    function getMaxLendingAmount(address lendingTokenAddress) external view returns (uint256);
-    
+
+    function getMaxLendingAmount(address lendingTokenAddress)
+        external
+        view
+        returns (uint256);
+
     function exceedsMaxLendingAmount(address lendingTokenAddress, uint256 amount)
-        external view returns (bool);
+        external
+        view
+        returns (bool);
 }

--- a/contracts/interfaces/SettingsInterface.sol
+++ b/contracts/interfaces/SettingsInterface.sol
@@ -9,6 +9,13 @@ interface SettingsInterface {
         uint256 newValue
     );
 
+    event MaxLendingAmountUpdated(
+        address indexed sender,
+        address indexed lendingToken,
+        uint256 oldValue,
+        uint256 newValue
+    );
+
     event LendingPoolPaused(address indexed account, address indexed lendingPoolAddress);
 
     event LendingPoolUnpaused(
@@ -47,4 +54,12 @@ interface SettingsInterface {
     function pauseLendingPool(address lendingPoolAddress) external;
 
     function unpauseLendingPool(address lendingPoolAddress) external;
+
+    function setMaxLendingAmount(address lendingTokenAddress, uint256 newMaxLendingAmount)
+        external;
+    
+    function getMaxLendingAmount(address lendingTokenAddress) external view returns (uint256);
+    
+    function exceedsMaxLendingAmount(address lendingTokenAddress, uint256 amount)
+        external view returns (bool);
 }

--- a/contracts/mock/base/LoansBaseModifiersMock.sol
+++ b/contracts/mock/base/LoansBaseModifiersMock.sol
@@ -33,4 +33,6 @@ contract LoansBaseModifiersMock is EtherCollateralLoans {
 
     function externalLoanActiveOrSet(uint256 loanID) loanActiveOrSet(loanID) external {}
 
+    function externalNotExceedsMaxAmount(uint256 amount) notExceedsMaxAmount(amount) external {}
+
 }

--- a/migrations/2_deploy.js
+++ b/migrations/2_deploy.js
@@ -1,8 +1,11 @@
 const assert = require('assert');
 const DeployerApp = require('./utils/DeployerApp');
 const PoolDeployer = require('./utils/PoolDeployer');
+const { toDecimals } = require('../test/utils/consts');
+
 
 // Official Smart Contracts
+const ERC20 = artifacts.require("openzeppelin-solidity/contracts/token/ERC20/ERC20Detailed.sol");
 const ZDAI = artifacts.require("./base/ZDAI.sol");
 const ZUSDC = artifacts.require("./base/ZUSDC.sol");
 const Settings = artifacts.require("./base/Settings.sol");
@@ -34,7 +37,7 @@ module.exports = async function(deployer, network, accounts) {
   const deployerAccountIndex = env.getDefaultAddressIndex().getOrDefault();
   const deployerAccount = accounts[deployerAccountIndex];
   console.log(`Deployer account index is ${deployerAccountIndex} => ${deployerAccount}`);
-  const { maxGasLimit, tokens, chainlink, compound } = networkConfig;
+  const { maxGasLimit, tokens, chainlink, compound, maxLendingAmounts } = networkConfig;
   assert(maxGasLimit, `Max gas limit for network ${network} is undefined.`);
 
   // Validations
@@ -57,6 +60,18 @@ module.exports = async function(deployer, network, accounts) {
     liquidateEthPrice,
     txConfig
   );
+  const settingsInstance = await Settings.deployed();
+  for (const tokenName of Object.keys(maxLendingAmounts)) {
+    const maxLendingAmountUnit = maxLendingAmounts[tokenName];
+    const tokenAddress = tokens[tokenName];
+    assert(tokenAddress, `MaxLendingAmount: Token address for token ${tokenName} is undefined.`);
+    const tokenInstance = await ERC20.at(tokenAddress);
+    const decimals = await tokenInstance.decimals();
+    const maxLendingAmountWithDecimals = toDecimals(maxLendingAmountUnit, decimals).toFixed(0);
+    console.log(`Configuring MAX lending amount => ${tokenName} / ${tokenAddress} = ${maxLendingAmountUnit} = ${maxLendingAmountWithDecimals}`);
+    await settingsInstance.setMaxLendingAmount(tokenAddress, maxLendingAmountWithDecimals, txConfig);
+  }
+
   const aggregators = {};
   
   for (const chainlinkOraclePair of chainlinkOraclesRequired) {

--- a/scripts/utils/cli-builder.js
+++ b/scripts/utils/cli-builder.js
@@ -97,6 +97,88 @@ module.exports = {
             return yargs;
         },
     },
+    tokens: {
+        mint: () => {
+            newOption(
+                yargs,
+                'tokenName',
+                'TN',
+                'string',
+                'Token name to mint.',
+                undefined,
+            );
+            newOption(
+                yargs,
+                'receiverIndex',
+                'RI',
+                'number',
+                'Address (index) that will receive the tokens.',
+                0,
+            );
+            newOption(
+                yargs,
+                'amount',
+                'A',
+                'number',
+                'Amount to mint. Default: 10000',
+                10000,
+            );
+            return yargs;
+        },
+        balanceOf: () => {
+            newOption(
+                yargs,
+                'tokenName',
+                'TN',
+                'string',
+                'Token name to mint.',
+                undefined,
+            );
+            newOption(
+                yargs,
+                'accountIndex',
+                'AI',
+                'number',
+                'Address (index) to verify the balance.',
+                0,
+            );
+
+            return yargs;
+        },
+    },
+    ganache: {
+        advanceTime: () => {
+            newOption(
+                yargs,
+                'network',
+                'N',
+                'string',
+                'Sets the network to use in the execution.',
+                undefined,
+            );
+            newOption(
+                yargs,
+                'seconds',
+                'S',
+                'number',
+                'Seconds to advance. Default: 120 seconds',
+                60 * 2,
+            );
+            return yargs;
+        },
+        setOraclePrice: () => {
+            loansBase(yargs);
+            newOption(
+                yargs,
+                'newValue',
+                'SI',
+                'number',
+                'New value.',
+                undefined,
+            );
+            return yargs;
+        },
+    },
     loans: {
         getAllLoansFor: () => {
             addLoansBase(yargs);
@@ -200,6 +282,51 @@ module.exports = {
             addNewValue(yargs);
             addSettingName(yargs);
             addSenderIndex(yargs);
+            return yargs;
+        },        
+    },
+    cTokens: () => {
+        newOption(
+            yargs,
+            'cTokenName',
+            'CTN',
+            'string',
+            'CToken name to get the exchange rate.',
+            undefined,
+        );
+        return yargs;
+    },
+    settings: {
+        view: () => {
+            base(yargs);
+            return yargs;
+        },
+        setNewSetting: (defaultValue = 10) => {
+            base(yargs);
+            newOption(
+                yargs,
+                'newValue',
+                'NV',
+                'string',
+                'New value to set. Time is in seconds.',
+                defaultValue,
+            );
+            newOption(
+                yargs,
+                'settingName',
+                'SN',
+                'string',
+                'Setting name to connfigure.',
+                undefined,
+            );
+            newOption(
+                yargs,
+                'senderIndex',
+                'SI',
+                'string',
+                `Sender index account. By default is 0`,
+                0,
+            );
             return yargs;
         },
     },

--- a/test/base/EtherCollateralLoansCreateLoanWithTermsTest.js
+++ b/test/base/EtherCollateralLoansCreateLoanWithTermsTest.js
@@ -9,6 +9,7 @@ const {
 } = require('../utils/consts');
 const { loans } = require('../utils/events');
 const { createLoanRequest, createUnsignedLoanResponse } = require('../utils/structs');
+const LendingPoolInterfaceEncoder = require('../utils/encoders/LendingPoolInterfaceEncoder');
 
 // Mock contracts
 const Mock = artifacts.require("./mock/util/Mock.sol");
@@ -19,6 +20,7 @@ const Settings = artifacts.require("./base/Settings.sol");
 const LoanTermsConsensus = artifacts.require("./base/LoanTermsConsensus.sol");
 
 contract('EtherCollateralLoansCreateLoanWithTermsTest', function (accounts) {
+    const lendingPoolInterfaceEncoder = new LendingPoolInterfaceEncoder(web3);
     let instance;
     let loanTermsConsInstance;
     let lendingPoolInstance;
@@ -69,6 +71,11 @@ contract('EtherCollateralLoansCreateLoanWithTermsTest', function (accounts) {
         msgValue,
     ) {    
         it(t('user', 'createLoanWithTerms', 'Should able to set loan terms.', false), async function() {
+            const lendingPoolTokenAddress = accounts[5];
+            const encodeLendingToken = lendingPoolInterfaceEncoder.encodeLendingToken();
+            await lendingPoolInstance.givenMethodReturnAddress(encodeLendingToken, lendingPoolTokenAddress);
+            await settingsInstance.setMaxLendingAmount(lendingPoolTokenAddress, loanRequest.amount);
+
             const interestRate = Math.floor((responseOne.interestRate + responseTwo.interestRate) / 2)
             const collateralRatio = Math.floor((responseOne.collateralRatio + responseTwo.collateralRatio) / 2)
             const maxLoanAmount = Math.floor((responseOne.maxLoanAmount + responseTwo.maxLoanAmount) / 2)

--- a/test/base/LoansBaseModifiersTest.js
+++ b/test/base/LoansBaseModifiersTest.js
@@ -1,15 +1,31 @@
 // JS Libraries
 const withData = require('leche').withData;
 const { t, NON_EXISTENT, ACTIVE, TERMS_SET, CLOSED } = require('../utils/consts');
+const SettingsInterfaceEncoder = require('../utils/encoders/SettingsInterfaceEncoder');
+
+// Mock contracts
+const Mock = artifacts.require("./mock/util/Mock.sol");
 
 // Smart contracts
 const LoansBaseModifiersMock = artifacts.require("./mock/base/LoansBaseModifiersMock.sol");
 
 contract('LoansBaseModifiersTest', function (accounts) {
-    let instance
+    const settingsInterfaceEncoder = new SettingsInterfaceEncoder(web3);
+    let instance;
+    let settingsInstance;
     
     beforeEach('Setup for each test', async () => {
-      instance = await LoansBaseModifiersMock.new(accounts[1], accounts[2], accounts[3], 5000);
+        const lendingPoolInstance = await Mock.new();
+        const oracleInstance = await Mock.new();
+        const loanTermsConsInstance = await Mock.new();
+        settingsInstance = await Mock.new()
+        instance = await LoansBaseModifiersMock.new();
+        await instance.initialize(
+            oracleInstance.address,
+            lendingPoolInstance.address,
+            loanTermsConsInstance.address,
+            settingsInstance.address
+        )
     });
 
     withData({
@@ -95,6 +111,36 @@ contract('LoansBaseModifiersTest', function (accounts) {
 
                 // Assertions
                 assert(!mustFail, 'It should have failed because loan is not active');
+                assert(result);
+            } catch (error) {
+                // Assertions
+                assert(mustFail);
+                assert(error);
+                assert.equal(error.reason, expectedErrorMessage);
+            }
+        });
+    });
+
+    withData({
+        _1_exceeds: [0, true, 'AMOUNT_EXCEEDS_MAX_AMOUNT', true],
+        _2_not_exceeds: [0, false, undefined, false],
+    }, function(
+        amount,
+        exceedsMaxLendingAmount,
+        expectedErrorMessage,
+        mustFail
+    ) {    
+        it(t('user', 'notExceedsMaxAmount', 'Should able (or not) to test whether amount exceeds the max amount or not.', mustFail), async function() {
+            // Setup
+            const encodeExceedsMaxLendingAmount = settingsInterfaceEncoder.encodeExceedsMaxLendingAmount();
+            await settingsInstance.givenMethodReturnBool(encodeExceedsMaxLendingAmount, exceedsMaxLendingAmount);
+
+            try {
+                // Invocation
+                const result = await instance.externalNotExceedsMaxAmount(amount);
+
+                // Assertions
+                assert(!mustFail, 'It should have failed because amount exceeds max');
                 assert(result);
             } catch (error) {
                 // Assertions

--- a/test/base/SettingsExceedsMaxLendingAmountTest.js
+++ b/test/base/SettingsExceedsMaxLendingAmountTest.js
@@ -1,0 +1,48 @@
+// JS Libraries
+const withData = require('leche').withData;
+const {
+    t,
+} = require('../utils/consts');
+
+// Mock contracts
+
+// Smart contracts
+const Settings = artifacts.require("./base/Settings.sol");
+
+contract('SettingsExceedsMaxLendingAmountTest', function (accounts) {
+    const INITIAL_VALUE = 1;
+    let instance;
+    
+    beforeEach('Setup for each test', async () => {
+        instance = await Settings.new(
+            INITIAL_VALUE, // Sets RequiredSubmissions
+            INITIAL_VALUE, // Sets MaximumTolerance
+            INITIAL_VALUE, // Sets ResponseExpiryLength
+            INITIAL_VALUE, // Sets SafetyInterval
+            INITIAL_VALUE, // Sets TermsExpiryTime
+            INITIAL_VALUE // Sets LiquidateEthPrice
+        );
+    });
+
+    withData({
+        _1_not_exceeds_max: [1, 1000, 100, false],
+        _2_exceeds_max: [2, 1000, 1200, true],
+        _3_same_value: [3, 1000, 1000, false],
+        _4_not_set: [4, 0, 1000, true],
+    }, function(lendingTokenIndex, currentValue, amountToTest, expectedResult) {
+        it(t('user', 'exceedsMaxLendingAmount', 'Should be able to test whether amount exceeds max lending amount.', false), async function() {
+            // Setup
+            const lendingTokenAddress = lendingTokenIndex === -1 ? NULL_ADDRESS : accounts[lendingTokenIndex];
+            const sender = accounts[0];
+            if (currentValue !== 0) {
+                await instance.setMaxLendingAmount(lendingTokenAddress, currentValue, { from: sender });
+            }
+
+            // Invocation
+            const result = await instance.exceedsMaxLendingAmount(lendingTokenAddress, amountToTest);
+            
+            // Assertions
+            assert.equal(result.toString(), expectedResult.toString());
+        });
+    });
+});

--- a/test/base/SettingsGetMaxLendingAmountTest.js
+++ b/test/base/SettingsGetMaxLendingAmountTest.js
@@ -1,0 +1,47 @@
+// JS Libraries
+const withData = require('leche').withData;
+const {
+    t,
+} = require('../utils/consts');
+
+// Mock contracts
+
+// Smart contracts
+const Settings = artifacts.require("./base/Settings.sol");
+
+contract('SettingsGetMaxLendingAmountTest', function (accounts) {
+    const INITIAL_VALUE = 1;
+    let instance;
+    
+    beforeEach('Setup for each test', async () => {
+        instance = await Settings.new(
+            INITIAL_VALUE, // Sets RequiredSubmissions
+            INITIAL_VALUE, // Sets MaximumTolerance
+            INITIAL_VALUE, // Sets ResponseExpiryLength
+            INITIAL_VALUE, // Sets SafetyInterval
+            INITIAL_VALUE, // Sets TermsExpiryTime
+            INITIAL_VALUE // Sets LiquidateEthPrice
+        );
+    });
+
+    withData({
+        _1_basic: [1, 1, 1],
+        _2_basic: [2, 1000, 1000],
+        _3_not_set: [3, 0, 0],
+    }, function(lendingTokenIndex, currentValue, expectedResult) {
+        it(t('user', 'getMaxLendingAmount', 'Should be able to get the current max lending amount.', false), async function() {
+            // Setup
+            const lendingTokenAddress = lendingTokenIndex === -1 ? NULL_ADDRESS : accounts[lendingTokenIndex];
+            const sender = accounts[0];
+            if (currentValue !== 0) {
+                await instance.setMaxLendingAmount(lendingTokenAddress, currentValue, { from: sender });
+            }
+
+            // Invocation
+            const result = await instance.getMaxLendingAmount(lendingTokenAddress);
+            
+            // Assertions
+            assert.equal(result.toString(), expectedResult.toString());
+        });
+    });
+});

--- a/test/base/SettingsSetSettingTest.js
+++ b/test/base/SettingsSetSettingTest.js
@@ -10,6 +10,7 @@ const {
     LIQUIDATE_ETH_PRICE,
     toBytes32,
     minutesToSeconds,
+    NULL_ADDRESS,
 } = require('../utils/consts');
 const { settings } = require('../utils/events');
 
@@ -207,6 +208,36 @@ contract('SettingsSetSettingTest', function (accounts) {
                 settings
                     .settingUpdated(result)
                     .emitted(toBytes32(web3, LIQUIDATE_ETH_PRICE), sender, oldValue, newValue);
+            } catch (error) {
+                // Assertions
+                assert(mustFail);
+                assert(error);
+                assert.equal(error.reason, expectedErrorMessage);
+            }
+        });
+    });
+
+    withData({
+        _1_basic: [0, 1, 100, 1000, undefined, false],
+        _2_new_value_required: [0, 2, 1000, 1000, 'NEW_MAX_AMOUNT_REQUIRED', true],
+    }, function(senderIndex, lendingTokenIndex, currentValue, newValue, expectedErrorMessage, mustFail) {
+        it(t('user', 'setMaxLendingAmount', 'Should (or not) be able to set a new max lending amount value.', mustFail), async function() {
+            // Setup
+            const lendingTokenAddress = lendingTokenIndex === -1 ? NULL_ADDRESS : accounts[lendingTokenIndex];
+            const sender = accounts[senderIndex];
+            await instance.setMaxLendingAmount(lendingTokenAddress, currentValue, { from: sender });
+
+            try {
+                // Invocation
+                const result = await instance.setMaxLendingAmount(lendingTokenAddress, newValue, { from: sender });
+                
+                // Assertions
+                assert(!mustFail, 'It should have failed because data is invalid.');
+                assert(result);
+
+                settings
+                    .maxLendingAmountUpdated(result)
+                    .emitted(sender, lendingTokenAddress, currentValue, newValue);
             } catch (error) {
                 // Assertions
                 assert(mustFail);

--- a/test/base/TokenCollateralLoansCreateLoanWithTermsTest.js
+++ b/test/base/TokenCollateralLoansCreateLoanWithTermsTest.js
@@ -12,6 +12,7 @@ const { createLoanRequest, createUnsignedLoanResponse } = require('../utils/stru
 const { assertLoan } = require('../utils/assertions');
 const Timer = require('../../scripts/utils/Timer');
 const LoanTermsConsensusEncoder = require('../utils/encoders/LoanTermsConsensusEncoder');
+const SettingsInterfaceEncoder = require('../utils/encoders/SettingsInterfaceEncoder');
 
 // Mock contracts
 const Mock = artifacts.require("./mock/util/Mock.sol");
@@ -51,10 +52,12 @@ const createTermsSetExpectedLoan = (
 };
 
 contract('TokenCollateralLoansCreateLoanWithTermsTest', function (accounts) {
+    const settingsInterfaceEncoder = new SettingsInterfaceEncoder(web3);
     let loanTermsConsensusEncoder;
     let collateralToken;
     let instance;
     let loanTermsConsInstance;
+    let settingsInstance;
 
     const timer = new Timer(web3);
     const borrowerAddress = accounts[2];
@@ -70,7 +73,7 @@ contract('TokenCollateralLoansCreateLoanWithTermsTest', function (accounts) {
         loanTermsConsInstance = await Mock.new();
         const lendingPoolInstance = await Mock.new();
         const oracleInstance = await Mock.new();
-        const settingsInstance = await Settings.new(1, 1, 1, 1, THIRTY_DAYS, 1)
+        settingsInstance = await Mock.new();
 
         loanRequest = createLoanRequest(borrowerAddress, NULL_ADDRESS, 3, 12000, 4, 19, loanTermsConsInstance.address);
         emptyRequest = createLoanRequest(NULL_ADDRESS, NULL_ADDRESS, 0, 0, 0, 0, loanTermsConsInstance.address);
@@ -97,6 +100,11 @@ contract('TokenCollateralLoansCreateLoanWithTermsTest', function (accounts) {
         _4_not_enough_allowance: [22, 3, 500000, 500000, 470000, 'NOT_ENOUGH_COLL_TOKENS_ALLOWANCE', true],
     }, function(loanID, senderIndex, mintAmount, collateralAmount, approveCollateralAmount, expectedErrorMessage, mustFail) {
         it(t('user', 'createLoanWithTerms', 'Should able to set loan terms.', mustFail), async function() {
+            // Setup
+            const encodeExceedsMaxLendingAmount = settingsInterfaceEncoder.encodeExceedsMaxLendingAmount();
+            await settingsInstance.givenMethodReturnBool(encodeExceedsMaxLendingAmount, false);
+            const encodeTermsExpiryTime = settingsInterfaceEncoder.encodeTermsExpiryTime();
+            await settingsInstance.givenMethodReturnUint(encodeTermsExpiryTime, THIRTY_DAYS);
             const sender = accounts[senderIndex];
             const interestRate = getAverage(responseOne.interestRate, responseTwo.interestRate);
             const collateralRatio = getAverage(responseOne.collateralRatio, responseTwo.collateralRatio);

--- a/test/utils/encoders/SettingsInterfaceEncoder.js
+++ b/test/utils/encoders/SettingsInterfaceEncoder.js
@@ -1,0 +1,18 @@
+const { encode } = require('../consts');
+
+class SettingsInterfaceEncoder {
+    constructor(web3) {
+        this.web3 = web3;
+        assert(web3, 'Web3 instance is required.');
+    }
+}
+
+SettingsInterfaceEncoder.prototype.encodeExceedsMaxLendingAmount = function() {
+    return encode(this.web3, 'exceedsMaxLendingAmount(address,uint256)');
+}
+
+SettingsInterfaceEncoder.prototype.encodeTermsExpiryTime = function() {
+    return encode(this.web3, 'termsExpiryTime()');
+}
+
+module.exports = SettingsInterfaceEncoder;

--- a/test/utils/events.js
+++ b/test/utils/events.js
@@ -294,5 +294,19 @@ module.exports = {
                 notEmitted: (assertFunction = () => {} ) => notEmitted(tx, name, assertFunction)
             };
         },
+        maxLendingAmountUpdated: tx => {
+            const name = 'MaxLendingAmountUpdated';
+            return {
+                name: name,
+                emitted: (sender, lendingToken, oldValue, newValue) => emitted(tx, name, ev => {
+                    assert.equal(ev.sender, sender);
+                    assert.equal(ev.lendingToken.toString(), lendingToken.toString());
+                    assert.equal(ev.oldValue.toString(), oldValue.toString());
+                    assert.equal(ev.newValue, newValue);
+
+                }),
+                notEmitted: (assertFunction = () => {} ) => notEmitted(tx, name, assertFunction)
+            };
+        },
     }
 };


### PR DESCRIPTION
It includes:

- Max lending amount per asset.
- Validation in Loans.setLoanTerms.
- Configuration for networks. (1000 by default).
- Unit tests.

![image](https://user-images.githubusercontent.com/5948309/86394235-9a596700-bc74-11ea-9636-b10288dce41a.png)
