### PR TITLE
[PROTOCOL-81] Adding Docs In Contracts II

### DIFF
--- a/contracts/base/EtherCollateralLoans.sol
+++ b/contracts/base/EtherCollateralLoans.sol
@@ -1,26 +1,15 @@
-/*
-    Copyright 2020 Fabrx Labs Inc.
-
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
-*/
-
 pragma solidity 0.5.17;
 pragma experimental ABIEncoderV2;
 
 // Contracts
 import "./LoansBase.sol";
 
+/**
+    @notice This contract is used as a basis for the creation of Ether based loans across the platform
+    @notice It implements the LoansBase contract from Teller
 
+    @author develop@teller.finance
+ */
 contract EtherCollateralLoans is LoansBase {
     address public collateralToken = 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE;
 
@@ -50,6 +39,12 @@ contract EtherCollateralLoans is LoansBase {
         emit CollateralDeposited(loanID, borrower, amount);
     }
 
+    /**
+        @notice Creates a loan with the loan request and terms
+        @param ZeroCollateralCommon.LoanRequest request Struct of the protocol loan request
+        @param ZeroCollateralCommon.LoanResponses request List of structs of the protocol loan responses
+        @param collateralAmount uint256 Amount of collateral required for the loan
+     */
     function createLoanWithTerms(
         ZeroCollateralCommon.LoanRequest calldata request,
         ZeroCollateralCommon.LoanResponse[] calldata responses,
@@ -94,6 +89,13 @@ contract EtherCollateralLoans is LoansBase {
         }
     }
 
+    /**
+        @notice Initializes the current contract instance setting the required parameters
+        @param priceOracleAddress address Contract address of the price oracle
+        @param lendingPoolAddress address Contract address of the lending pool
+        @parm loanTermConsensusAddress address Contract adddress for loan term consensus
+        @param settingsAddress address Contract address for the configuration of the platform
+     */
     function initialize(
         address priceOracleAddress,
         address lendingPoolAddress,
@@ -109,7 +111,11 @@ contract EtherCollateralLoans is LoansBase {
     }
 
     /** Internal Functions */
-
+    /**
+        @notice Pays out collateral for the associated loan
+        @param loanID uint256 The ID of the loan the collateral is for
+        @param amount uint256 The amount of collateral to be paid
+     */
     function _payOutCollateral(uint256 loanID, uint256 amount, address payable recipient)
         internal
     {

--- a/contracts/base/EtherCollateralLoans.sol
+++ b/contracts/base/EtherCollateralLoans.sol
@@ -15,8 +15,8 @@ contract EtherCollateralLoans is LoansBase {
 
     /**
      * @notice Deposit collateral into a loan
-     * @param borrower address The address of the loan borrower.
-     * @param loanID uint256 The ID of the loan the collateral is for
+     * @param borrower The address of the loan borrower.
+     * @param loanID The ID of the loan the collateral is for
      */
     function depositCollateral(address borrower, uint256 loanID, uint256 amount)
         external
@@ -41,9 +41,9 @@ contract EtherCollateralLoans is LoansBase {
 
     /**
         @notice Creates a loan with the loan request and terms
-        @param ZeroCollateralCommon.LoanRequest request Struct of the protocol loan request
-        @param ZeroCollateralCommon.LoanResponses request List of structs of the protocol loan responses
-        @param collateralAmount uint256 Amount of collateral required for the loan
+        @param request Struct of the protocol loan request
+        @param responses List of structs of the protocol loan responses
+        @param collateralAmount Amount of collateral required for the loan
      */
     function createLoanWithTerms(
         ZeroCollateralCommon.LoanRequest calldata request,
@@ -91,10 +91,10 @@ contract EtherCollateralLoans is LoansBase {
 
     /**
         @notice Initializes the current contract instance setting the required parameters
-        @param priceOracleAddress address Contract address of the price oracle
-        @param lendingPoolAddress address Contract address of the lending pool
-        @parm loanTermConsensusAddress address Contract adddress for loan term consensus
-        @param settingsAddress address Contract address for the configuration of the platform
+        @param priceOracleAddress Contract address of the price oracle
+        @param lendingPoolAddress Contract address of the lending pool
+        @param loanTermsConsensusAddress Contract adddress for loan term consensus
+        @param settingsAddress Contract address for the configuration of the platform
      */
     function initialize(
         address priceOracleAddress,
@@ -113,8 +113,8 @@ contract EtherCollateralLoans is LoansBase {
     /** Internal Functions */
     /**
         @notice Pays out collateral for the associated loan
-        @param loanID uint256 The ID of the loan the collateral is for
-        @param amount uint256 The amount of collateral to be paid
+        @param loanID The ID of the loan the collateral is for
+        @param amount The amount of collateral to be paid
      */
     function _payOutCollateral(uint256 loanID, uint256 amount, address payable recipient)
         internal

--- a/contracts/base/LoanTermsConsensus.sol
+++ b/contracts/base/LoanTermsConsensus.sol
@@ -19,8 +19,8 @@ contract LoanTermsConsensus is Consensus, LoanTermsConsensusInterface {
 
     /**
         @notice Processes the loan request
-        @param ZeroCollateralCommon.LoanRequest request Struct of the protocol loan request
-        @param ZeroCollateralCommon.LoanResponses request List of structs of the protocol loan responses
+        @param request Struct of the protocol loan request
+        @param responses List of structs of the protocol loan responses
         @return uint256 Interest rate
         @return uint256 Collateral ratio
         @return uint256 Maximum loan amount
@@ -71,8 +71,8 @@ contract LoanTermsConsensus is Consensus, LoanTermsConsensusInterface {
 
     /**
         @notice Processes the loan response
-        @param ZeroCollateralCommon.LoanRequest request Struct of the protocol loan request
-        @param ZeroCollateralCommon.LoanResponses request List of structs of the protocol loan responses
+        @param request Struct of the protocol loan request
+        @param response List of structs of the protocol loan responses
         @param requestHash bytes32 Hash of the loan request
      */
     function _processResponse(
@@ -113,8 +113,8 @@ contract LoanTermsConsensus is Consensus, LoanTermsConsensusInterface {
 
     /**
         @notice Generates a hash for the loan response
-        @param ZeroCollateralCommon.LoanResponses request Structs of the protocol loan responses
-        @param requestHash bytes32 Hash of the loan request
+        @param response Structs of the protocol loan responses
+        @param requestHash Hash of the loan request
         @return bytes32 Hash of the loan response
      */
     function _hashResponse(
@@ -138,7 +138,7 @@ contract LoanTermsConsensus is Consensus, LoanTermsConsensusInterface {
 
     /**
         @notice Generates a hash for the loan request
-        @param ZeroCollateralCommon.LoanRequest request Struct of the protocol loan request
+        @param request Struct of the protocol loan request
         @return bytes32 Hash of the loan request
      */
     function _hashRequest(ZeroCollateralCommon.LoanRequest memory request)

--- a/contracts/base/LoanTermsConsensus.sol
+++ b/contracts/base/LoanTermsConsensus.sol
@@ -1,18 +1,3 @@
-/*
-    Copyright 2020 Fabrx Labs Inc.
-
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
-*/
 pragma solidity 0.5.17;
 pragma experimental ABIEncoderV2;
 
@@ -22,11 +7,24 @@ import "./Consensus.sol";
 // Interfaces
 import "../interfaces/LoanTermsConsensusInterface.sol";
 
+/**
+    @notice This contract is used to process the loan requests through the Teller protocol
 
+    @author develop@teller.finance
+ */
 contract LoanTermsConsensus is Consensus, LoanTermsConsensusInterface {
+    /* Mappings */
     mapping(address => mapping(uint256 => ZeroCollateralCommon.AccruedLoanTerms)) public termSubmissions;
     mapping(address => mapping(uint256 => bool)) public requestNonceTaken;
 
+    /**
+        @notice Processes the loan request
+        @param ZeroCollateralCommon.LoanRequest request Struct of the protocol loan request
+        @param ZeroCollateralCommon.LoanResponses request List of structs of the protocol loan responses
+        @return uint256 Interest rate
+        @return uint256 Collateral ratio
+        @return uint256 Maximum loan amount
+     */
     function processRequest(
         ZeroCollateralCommon.LoanRequest calldata request,
         ZeroCollateralCommon.LoanResponse[] calldata responses
@@ -71,6 +69,12 @@ contract LoanTermsConsensus is Consensus, LoanTermsConsensusInterface {
         );
     }
 
+    /**
+        @notice Processes the loan response
+        @param ZeroCollateralCommon.LoanRequest request Struct of the protocol loan request
+        @param ZeroCollateralCommon.LoanResponses request List of structs of the protocol loan responses
+        @param requestHash bytes32 Hash of the loan request
+     */
     function _processResponse(
         ZeroCollateralCommon.LoanRequest memory request,
         ZeroCollateralCommon.LoanResponse memory response,
@@ -107,6 +111,12 @@ contract LoanTermsConsensus is Consensus, LoanTermsConsensusInterface {
         );
     }
 
+    /**
+        @notice Generates a hash for the loan response
+        @param ZeroCollateralCommon.LoanResponses request Structs of the protocol loan responses
+        @param requestHash bytes32 Hash of the loan request
+        @return bytes32 Hash of the loan response
+     */
     function _hashResponse(
         ZeroCollateralCommon.LoanResponse memory response,
         bytes32 requestHash
@@ -126,6 +136,11 @@ contract LoanTermsConsensus is Consensus, LoanTermsConsensusInterface {
             );
     }
 
+    /**
+        @notice Generates a hash for the loan request
+        @param ZeroCollateralCommon.LoanRequest request Struct of the protocol loan request
+        @return bytes32 Hash of the loan request
+     */
     function _hashRequest(ZeroCollateralCommon.LoanRequest memory request)
         internal
         view

--- a/contracts/base/LoansBase.sol
+++ b/contracts/base/LoansBase.sol
@@ -331,7 +331,7 @@ contract LoansBase is LoansInterface, Base {
 
     /** Internal Functions */
     /**
-        @notice Payouts the collateral for a loan
+        @notice Pays out the collateral for a loan
         @param loanID ID of loan from which collateral is to be paid out
         @param amount Amount of collateral paid out
         @param recipient Account address of the recipient of the collateral

--- a/contracts/base/LoansBase.sol
+++ b/contracts/base/LoansBase.sol
@@ -54,7 +54,7 @@ contract LoansBase is LoansInterface, Base {
     /**
         @notice Checks if the sender is a borrower or not
         @dev It throws a require error if the sender is not a borrower
-        @param Borrower address to check
+        @param borrower Account address to check
      */
     modifier isBorrower(address borrower) {
         require(msg.sender == borrower, "BORROWER_MUST_BE_SENDER");
@@ -64,7 +64,7 @@ contract LoansBase is LoansInterface, Base {
     /**
         @notice Checks whether the loan is active or not
         @dev Throws a require error if the loan is not active
-        @param ID number of loan to check
+        @param loanID number of loan to check
      */
     modifier loanActive(uint256 loanID) {
         require(
@@ -77,7 +77,7 @@ contract LoansBase is LoansInterface, Base {
     /**
         @notice Checks if the loan has been set or not
         @dev Throws a require error if the loan terms have not been set
-        @param ID number of loan to check
+        @param loanID number of loan to check
      */
     modifier loanTermsSet(uint256 loanID) {
         require(
@@ -90,7 +90,7 @@ contract LoansBase is LoansInterface, Base {
     /**
         @notice Checks whether the loan is active and has been set or not
         @dev Throws a require error if the loan is not active or has not been set
-        @param ID number of loan to check
+        @param loanID number of loan to check
      */
     modifier loanActiveOrSet(uint256 loanID) {
         require(
@@ -103,7 +103,7 @@ contract LoansBase is LoansInterface, Base {
 
     /**
         @notice Get a list of all loans for a borrower
-        @param Borrower address The borrower's address
+        @param borrower The borrower's address
      */
     function getBorrowerLoans(address borrower) external view returns (uint256[] memory) {
         return borrowerLoans[borrower];
@@ -119,8 +119,8 @@ contract LoansBase is LoansInterface, Base {
 
     /**
      * @notice Withdraw collateral from a loan, unless this isn't allowed
-     * @param amount uint256 The amount of collateral token or ether the caller is hoping to withdraw.
-     * @param loanID uint256 The ID of the loan the collateral is for
+     * @param amount The amount of collateral token or ether the caller is hoping to withdraw.
+     * @param loanID The ID of the loan the collateral is for
      */
     function withdrawCollateral(uint256 amount, uint256 loanID)
         external
@@ -211,8 +211,8 @@ contract LoansBase is LoansInterface, Base {
 
     /**
      * @notice Make a payment to a loan
-     * @param amount uint256 The amount of tokens to pay back to the loan
-     * @param loanID uint256 The ID of the loan the payment is for
+     * @param amount The amount of tokens to pay back to the loan
+     * @param loanID The ID of the loan the payment is for
      */
     function repay(uint256 amount, uint256 loanID)
         external
@@ -262,7 +262,7 @@ contract LoansBase is LoansInterface, Base {
 
     /**
      * @notice Liquidate a loan if it is expired or undercollateralised
-     * @param loanID uint256 The ID of the loan to be liquidated
+     * @param loanID The ID of the loan to be liquidated
      */
     function liquidateLoan(uint256 loanID)
         external
@@ -310,7 +310,7 @@ contract LoansBase is LoansInterface, Base {
 
     /**
         @notice Get collateral infomation of a specific loan
-        @param Loan ID of the loan to get info for
+        @param loanID of the loan to get info for
         @return uint256 Collateral needed
         @return uint256 Collaternal needed in Lending tokens
         @return uint256 Collateral needed in Collateral tokens (wei)
@@ -332,16 +332,16 @@ contract LoansBase is LoansInterface, Base {
     /** Internal Functions */
     /**
         @notice Payouts the collateral for a loan
-        @param loanID uint256 ID of loan from which collateral is to be paid out
-        @param amount uint256 Amount of collateral paid out
-        @param recipient address Account address of the recipient of the collateral
+        @param loanID ID of loan from which collateral is to be paid out
+        @param amount Amount of collateral paid out
+        @param recipient Account address of the recipient of the collateral
      */
     function _payOutCollateral(uint256 loanID, uint256 amount, address payable recipient)
         internal;
 
     /**
         @notice Get collateral infomation of a specific loan
-        @param Loan ID of the loan to get info for
+        @param loanID of the loan to get info for
         @return uint256 Collateral needed
         @return uint256 Collaternal needed in Lending tokens
         @return uint256 Collateral needed in Collateral tokens (wei)
@@ -370,8 +370,8 @@ contract LoansBase is LoansInterface, Base {
 
     /**
        @notice Get information on the collateral needed for the loan
-       @param totalOwed uint256 Total amount owed for the loan
-       @param collateralRatio uint256 Collateral ratio set in the loan terms
+       @param totalOwed Total amount owed for the loan
+       @param collateralRatio Collateral ratio set in the loan terms
        @return uint256 Collaternal needed in Lending tokens
        @return uint256 Collateral needed in Collateral tokens (wei)
      */
@@ -394,10 +394,10 @@ contract LoansBase is LoansInterface, Base {
 
     /**
         @notice Initializes the current contract instance setting the required parameters.
-        @param priceOracleAddress address Contract address of the price oracle
-        @param lendingPoolAddress address Contract address of the lending pool
-        @parm loanTermConsensusAddress address Contract adddress for loan term consensus
-        @param settingsAddress address Contract address for the configuration of the platform
+        @param priceOracleAddress Contract address of the price oracle
+        @param lendingPoolAddress Contract address of the lending pool
+        @param loanTermsConsensusAddress Contract adddress for loan term consensus
+        @param settingsAddress Contract address for the configuration of the platform
      */
     function _initialize(
         address priceOracleAddress,
@@ -418,8 +418,8 @@ contract LoansBase is LoansInterface, Base {
 
     /**
         @notice Pays collateral in for the associated loan
-        @param loanID uint256 The ID of the loan the collateral is for
-        @param amount uint256 The amount of collateral to be paid
+        @param loanID The ID of the loan the collateral is for
+        @param amount The amount of collateral to be paid
      */
     function _payInCollateral(uint256 loanID, uint256 amount) internal {
         totalCollateral = totalCollateral.add(amount);
@@ -429,8 +429,8 @@ contract LoansBase is LoansInterface, Base {
 
     /**
         @notice Make a payment towards the prinicial and interest for a specified loan
-        @param loanID uint256 The ID of the loan the payment is for
-        @param amount uint256 The amount of tokens to pay to the loan
+        @param loanID The ID of the loan the payment is for
+        @param toPay The amount of tokens to pay to the loan
      */
     function _payLoan(uint256 loanID, uint256 toPay) internal {
         if (toPay > loans[loanID].principalOwed) {
@@ -445,7 +445,7 @@ contract LoansBase is LoansInterface, Base {
 
     /**
         @notice Returns the total owed amount remaining for a specified loan
-        @param loanID uint256 The ID of the loan to be queried
+        @param loanID The ID of the loan to be queried
         @return uint256 The total amount owed remaining
      */
     function _getTotalOwed(uint256 loanID) internal view returns (uint256) {
@@ -463,8 +463,8 @@ contract LoansBase is LoansInterface, Base {
 
     /**
         @notice Returns the value of collateral
-        @param loanAmount uint256 The total amount of the loan for which collateral is needed
-        @param collateralRatio uint256 Collateral ratio set in the loan terms
+        @param loanAmount The total amount of the loan for which collateral is needed
+        @param collateralRatio Collateral ratio set in the loan terms
         @return uint256 The amount of collateral needed in lending tokens (not wei)
      */
     function _getCollateralNeededInTokens(uint256 loanAmount, uint256 collateralRatio)
@@ -477,7 +477,7 @@ contract LoansBase is LoansInterface, Base {
 
     /**
         @notice Converts the collateral tokens to lending tokens
-        @param weiAmount uin256 The amount of wei to be converted
+        @param weiAmount The amount of wei to be converted
         @return uint256 The value the collateal tokens (wei) in lending tokens (not wei)
      */
     function _convertWeiToToken(uint256 weiAmount) internal view returns (uint256) {
@@ -491,8 +491,8 @@ contract LoansBase is LoansInterface, Base {
     }
 
     /**
-        @param Converts the lending token to collareal tokens
-        @param tokenAmount uint256 The amount in lending tokens (not wei) to be converted
+        @notice Converts the lending token to collareal tokens
+        @param tokenAmount The amount in lending tokens (not wei) to be converted
         @return uint256 The value of lending tokens (not wei) in collateral tokens (wei)
      */
     function _convertTokenToWei(uint256 tokenAmount) internal view returns (uint256) {
@@ -517,11 +517,11 @@ contract LoansBase is LoansInterface, Base {
 
     /**
         @notice Creates a loan with the loan request
-        @param loanID uint256 The ID of the loan
-        @param request ZeroCollateralCommon.LoanRequest Loan request as per the struct of the Teller platform
-        @param interestRate uint256 Interest rate set in the loan terms
-        @param collateralRatio uint256 Collateral ratio set in the loan terms
-        @param maxLoanAmount uint256 Maximum loan amount that can be taken out, set in the loan terms
+        @param loanID The ID of the loan
+        @param request Loan request as per the struct of the Teller platform
+        @param interestRate Interest rate set in the loan terms
+        @param collateralRatio Collateral ratio set in the loan terms
+        @param maxLoanAmount Maximum loan amount that can be taken out, set in the loan terms
         @return memory ZeroCollateralCommon.Loan Loan struct as per the Teller platform
      */
     function createLoan(

--- a/contracts/base/LoansBase.sol
+++ b/contracts/base/LoansBase.sol
@@ -1,19 +1,3 @@
-/*
-    Copyright 2020 Fabrx Labs Inc.
-
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
-*/
-
 pragma solidity 0.5.17;
 pragma experimental ABIEncoderV2;
 
@@ -31,9 +15,16 @@ import "../interfaces/LendingPoolInterface.sol";
 import "../interfaces/LoanTermsConsensusInterface.sol";
 import "../interfaces/LoansInterface.sol";
 
+/**
+    @notice This contract is used as a basis for the creation of the different types of loans across the platform
+    @notice It implements the Base contract from Teller and the LoansInterface
 
+    @author develop@teller.finance
+ */
 contract LoansBase is LoansInterface, Base {
     using SafeMath for uint256;
+
+    /* State Variables */
 
     uint256 internal constant TEN = 10; // Used to calculate one whole token.
     // Loan length will be inputted in days, with 4 decimal places. i.e. 30 days will be inputted as
@@ -58,11 +49,23 @@ contract LoansBase is LoansInterface, Base {
 
     mapping(uint256 => ZeroCollateralCommon.Loan) public loans;
 
+    /* Modifiers */
+
+    /**
+        @notice Checks if the sender is a borrower or not
+        @dev It throws a require error if the sender is not a borrower
+        @param Borrower address to check
+     */
     modifier isBorrower(address borrower) {
         require(msg.sender == borrower, "BORROWER_MUST_BE_SENDER");
         _;
     }
 
+    /**
+        @notice Checks whether the loan is active or not
+        @dev Throws a require error if the loan is not active
+        @param ID number of loan to check
+     */
     modifier loanActive(uint256 loanID) {
         require(
             loans[loanID].status == ZeroCollateralCommon.LoanStatus.Active,
@@ -71,6 +74,11 @@ contract LoansBase is LoansInterface, Base {
         _;
     }
 
+    /**
+        @notice Checks if the loan has been set or not
+        @dev Throws a require error if the loan terms have not been set
+        @param ID number of loan to check
+     */
     modifier loanTermsSet(uint256 loanID) {
         require(
             loans[loanID].status == ZeroCollateralCommon.LoanStatus.TermsSet,
@@ -79,6 +87,11 @@ contract LoansBase is LoansInterface, Base {
         _;
     }
 
+    /**
+        @notice Checks whether the loan is active and has been set or not
+        @dev Throws a require error if the loan is not active or has not been set
+        @param ID number of loan to check
+     */
     modifier loanActiveOrSet(uint256 loanID) {
         require(
             loans[loanID].status == ZeroCollateralCommon.LoanStatus.TermsSet ||
@@ -89,13 +102,17 @@ contract LoansBase is LoansInterface, Base {
     }
 
     /**
-     * @notice Get a list of all loans for a borrower
-     * @param borrower address The borrower's address
+        @notice Get a list of all loans for a borrower
+        @param Borrower address The borrower's address
      */
     function getBorrowerLoans(address borrower) external view returns (uint256[] memory) {
         return borrowerLoans[borrower];
     }
 
+    /**
+        @notice Returns the lending token in the lending pool
+        @return Address of the lending token
+     */
     function lendingToken() external view returns (address) {
         return lendingPool.lendingToken();
     }
@@ -291,6 +308,14 @@ contract LoansBase is LoansInterface, Base {
         );
     }
 
+    /**
+        @notice Get collateral infomation of a specific loan
+        @param Loan ID of the loan to get info for
+        @return uint256 Collateral needed
+        @return uint256 Collaternal needed in Lending tokens
+        @return uint256 Collateral needed in Collateral tokens (wei)
+        @return bool If more collateral is needed or not
+     */
     function getCollateralInfo(uint256 loanID)
         external
         view
@@ -305,10 +330,23 @@ contract LoansBase is LoansInterface, Base {
     }
 
     /** Internal Functions */
-
+    /**
+        @notice Payouts the collateral for a loan
+        @param loanID uint256 ID of loan from which collateral is to be paid out
+        @param amount uint256 Amount of collateral paid out
+        @param recipient address Account address of the recipient of the collateral
+     */
     function _payOutCollateral(uint256 loanID, uint256 amount, address payable recipient)
         internal;
 
+    /**
+        @notice Get collateral infomation of a specific loan
+        @param Loan ID of the loan to get info for
+        @return uint256 Collateral needed
+        @return uint256 Collaternal needed in Lending tokens
+        @return uint256 Collateral needed in Collateral tokens (wei)
+        @return bool If more collateral is needed or not
+     */
     function _getCollateralInfo(uint256 loanID)
         internal
         view
@@ -330,6 +368,13 @@ contract LoansBase is LoansInterface, Base {
         moreCollateralRequired = collateralNeededCollateralTokens > collateral;
     }
 
+    /**
+       @notice Get information on the collateral needed for the loan
+       @param totalOwed uint256 Total amount owed for the loan
+       @param collateralRatio uint256 Collateral ratio set in the loan terms
+       @return uint256 Collaternal needed in Lending tokens
+       @return uint256 Collateral needed in Collateral tokens (wei)
+     */
     function _getCollateralNeededInfo(uint256 totalOwed, uint256 collateralRatio)
         internal
         view
@@ -347,6 +392,13 @@ contract LoansBase is LoansInterface, Base {
         return (collateralNeededToken, _convertTokenToWei(collateralNeededToken));
     }
 
+    /**
+        @notice Initializes the current contract instance setting the required parameters.
+        @param priceOracleAddress address Contract address of the price oracle
+        @param lendingPoolAddress address Contract address of the lending pool
+        @parm loanTermConsensusAddress address Contract adddress for loan term consensus
+        @param settingsAddress address Contract address for the configuration of the platform
+     */
     function _initialize(
         address priceOracleAddress,
         address lendingPoolAddress,
@@ -364,12 +416,22 @@ contract LoansBase is LoansInterface, Base {
         loanTermsConsensus = LoanTermsConsensusInterface(loanTermsConsensusAddress);
     }
 
+    /**
+        @notice Pays collateral in for the associated loan
+        @param loanID uint256 The ID of the loan the collateral is for
+        @param amount uint256 The amount of collateral to be paid
+     */
     function _payInCollateral(uint256 loanID, uint256 amount) internal {
         totalCollateral = totalCollateral.add(amount);
         loans[loanID].collateral = loans[loanID].collateral.add(amount);
         loans[loanID].lastCollateralIn = now;
     }
 
+    /**
+        @notice Make a payment towards the prinicial and interest for a specified loan
+        @param loanID uint256 The ID of the loan the payment is for
+        @param amount uint256 The amount of tokens to pay to the loan
+     */
     function _payLoan(uint256 loanID, uint256 toPay) internal {
         if (toPay > loans[loanID].principalOwed) {
             uint256 leftToPay = toPay;
@@ -381,24 +443,43 @@ contract LoansBase is LoansInterface, Base {
         }
     }
 
+    /**
+        @notice Returns the total owed amount remaining for a specified loan
+        @param loanID uint256 The ID of the loan to be queried
+        @return uint256 The total amount owed remaining
+     */
     function _getTotalOwed(uint256 loanID) internal view returns (uint256) {
         return loans[loanID].interestOwed.add(loans[loanID].principalOwed);
     }
 
+    /**
+        @notice Returns a calculated whole lending token
+        @return uint256 A whole lending token calcuated using token case units
+     */
     function _getAWholeLendingToken() internal view returns (uint256) {
         uint8 decimals = ERC20Detailed(lendingPool.lendingToken()).decimals();
         return TEN**decimals;
     }
 
+    /**
+        @notice Returns the value of collateral
+        @param loanAmount uint256 The total amount of the loan for which collateral is needed
+        @param collateralRatio uint256 Collateral ratio set in the loan terms
+        @return uint256 The amount of collateral needed in lending tokens (not wei)
+     */
     function _getCollateralNeededInTokens(uint256 loanAmount, uint256 collateralRatio)
         internal
         pure
         returns (uint256)
     {
-        // gets the amount of collateral needed in lending tokens (not wei)
         return loanAmount.mul(collateralRatio).div(TEN_THOUSAND);
     }
 
+    /**
+        @notice Converts the collateral tokens to lending tokens
+        @param weiAmount uin256 The amount of wei to be converted
+        @return uint256 The value the collateal tokens (wei) in lending tokens (not wei)
+     */
     function _convertWeiToToken(uint256 weiAmount) internal view returns (uint256) {
         // wei amount / lending token price in wei * the lending token decimals.
         uint256 aWholeLendingToken = _getAWholeLendingToken();
@@ -409,6 +490,11 @@ contract LoansBase is LoansInterface, Base {
         return tokenValue;
     }
 
+    /**
+        @param Converts the lending token to collareal tokens
+        @param tokenAmount uint256 The amount in lending tokens (not wei) to be converted
+        @return uint256 The value of lending tokens (not wei) in collateral tokens (wei)
+     */
     function _convertTokenToWei(uint256 tokenAmount) internal view returns (uint256) {
         // tokenAmount is in token units, chainlink price is in whole tokens
         // token amount in tokens * lending token price in wei / the lending token decimals.
@@ -420,11 +506,24 @@ contract LoansBase is LoansInterface, Base {
         return weiValue;
     }
 
+    /**
+        @notice Returns the current loan ID and increments it by 1
+        @return uint256 The current loan ID before incrementing
+     */
     function getAndIncrementLoanID() internal returns (uint256 newLoanID) {
         newLoanID = loanIDCounter;
         loanIDCounter += 1;
     }
 
+    /**
+        @notice Creates a loan with the loan request
+        @param loanID uint256 The ID of the loan
+        @param request ZeroCollateralCommon.LoanRequest Loan request as per the struct of the Teller platform
+        @param interestRate uint256 Interest rate set in the loan terms
+        @param collateralRatio uint256 Collateral ratio set in the loan terms
+        @param maxLoanAmount uint256 Maximum loan amount that can be taken out, set in the loan terms
+        @return memory ZeroCollateralCommon.Loan Loan struct as per the Teller platform
+     */
     function createLoan(
         uint256 loanID,
         ZeroCollateralCommon.LoanRequest memory request,

--- a/contracts/base/TokenCollateralLoans.sol
+++ b/contracts/base/TokenCollateralLoans.sol
@@ -1,24 +1,15 @@
-/*
-    Copyright 2020 Fabrx Labs Inc.
-
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
-*/
-
 pragma solidity 0.5.17;
 pragma experimental ABIEncoderV2;
 
 // Contracts
 import "./LoansBase.sol";
+
+/**
+    @notice This contract is used as a basis for the creation of loans (not wei) across the platform
+    @notice It implements the LoansBase contract from Teller
+
+    @author develop@teller.finance
+ */
 
 
 contract TokenCollateralLoans is LoansBase {
@@ -63,6 +54,12 @@ contract TokenCollateralLoans is LoansBase {
         emit CollateralDeposited(loanID, borrower, amount);
     }
 
+    /**
+        @notice Creates a loan with the loan request and terms
+        @param ZeroCollateralCommon.LoanRequest request Struct of the protocol loan request
+        @param ZeroCollateralCommon.LoanResponses request List of structs of the protocol loan responses
+        @param collateralAmount uint256 Amount of collateral required for the loan
+     */
     function createLoanWithTerms(
         ZeroCollateralCommon.LoanRequest calldata request,
         ZeroCollateralCommon.LoanResponse[] calldata responses,
@@ -113,6 +110,13 @@ contract TokenCollateralLoans is LoansBase {
         }
     }
 
+    /**
+        @notice Initializes the current contract instance setting the required parameters, if allowed
+        @param priceOracleAddress address Contract address of the price oracle
+        @param lendingPoolAddress address Contract address of the lending pool
+        @parm loanTermConsensusAddress address Contract adddress for loan term consensus
+        @param settingsAddress address Contract address for the configuration of the platform
+     */
     function initialize(
         address priceOracleAddress,
         address lendingPoolAddress,
@@ -133,7 +137,11 @@ contract TokenCollateralLoans is LoansBase {
     }
 
     /** Internal Function */
-
+    /**
+        @notice Pays out collateral for the associated loan
+        @param loanID uint256 The ID of the loan the collateral is for
+        @param amount uint256 The amount of collateral to be paid
+     */
     function _payOutCollateral(uint256 loanID, uint256 amount, address payable recipient)
         internal
     {
@@ -142,6 +150,11 @@ contract TokenCollateralLoans is LoansBase {
         collateralTokenTransfer(recipient, amount);
     }
 
+    /**
+        @notice Pays collateral in for the associated loan
+        @param loanID uint256 The ID of the loan the collateral is for
+        @param amount uint256 The amount of collateral to be paid
+     */
     function _payInCollateral(uint256 loanID, uint256 amount) internal {
         // Update the total collateral and loan collateral
         super._payInCollateral(loanID, amount);
@@ -149,6 +162,12 @@ contract TokenCollateralLoans is LoansBase {
         collateralTokenTransferFrom(msg.sender, amount);
     }
 
+    /**
+        @notice Checks to ensure the token balance matches the required balance
+        @param initialBalance uint256 The inital balance of tokens
+        @param expectedAmount uint256 The expected balance of tokens
+        @param isTransfer bool If the balance is being checked for a transfer or token allowance
+     */
     function _requireExpectedBalance(
         uint256 initialBalance,
         uint256 expectedAmount,

--- a/contracts/base/TokenCollateralLoans.sol
+++ b/contracts/base/TokenCollateralLoans.sol
@@ -29,9 +29,9 @@ contract TokenCollateralLoans is LoansBase {
 
     /**
      * @notice Deposit collateral tokens into a loan.
-     * @param borrower address The address of the loan borrower.
-     * @param loanID uint256 The ID of the loan the collateral is for
-     * @param amount to deposit as collateral.
+     * @param borrower The address of the loan borrower.
+     * @param loanID The ID of the loan the collateral is for
+     * @param amount The amount to deposit as collateral.
      */
     function depositCollateral(address borrower, uint256 loanID, uint256 amount)
         external
@@ -56,9 +56,9 @@ contract TokenCollateralLoans is LoansBase {
 
     /**
         @notice Creates a loan with the loan request and terms
-        @param ZeroCollateralCommon.LoanRequest request Struct of the protocol loan request
-        @param ZeroCollateralCommon.LoanResponses request List of structs of the protocol loan responses
-        @param collateralAmount uint256 Amount of collateral required for the loan
+        @param request Struct of the protocol loan request
+        @param responses List of structs of the protocol loan responses
+        @param collateralAmount Amount of collateral required for the loan
      */
     function createLoanWithTerms(
         ZeroCollateralCommon.LoanRequest calldata request,
@@ -112,10 +112,10 @@ contract TokenCollateralLoans is LoansBase {
 
     /**
         @notice Initializes the current contract instance setting the required parameters, if allowed
-        @param priceOracleAddress address Contract address of the price oracle
-        @param lendingPoolAddress address Contract address of the lending pool
-        @parm loanTermConsensusAddress address Contract adddress for loan term consensus
-        @param settingsAddress address Contract address for the configuration of the platform
+        @param priceOracleAddress Contract address of the price oracle
+        @param lendingPoolAddress Contract address of the lending pool
+        @param loanTermsConsensusAddress Contract adddress for loan term consensus
+        @param settingsAddress Contract address for the configuration of the platform
      */
     function initialize(
         address priceOracleAddress,
@@ -139,8 +139,8 @@ contract TokenCollateralLoans is LoansBase {
     /** Internal Function */
     /**
         @notice Pays out collateral for the associated loan
-        @param loanID uint256 The ID of the loan the collateral is for
-        @param amount uint256 The amount of collateral to be paid
+        @param loanID The ID of the loan the collateral is for
+        @param amount The amount of collateral to be paid
      */
     function _payOutCollateral(uint256 loanID, uint256 amount, address payable recipient)
         internal
@@ -152,8 +152,8 @@ contract TokenCollateralLoans is LoansBase {
 
     /**
         @notice Pays collateral in for the associated loan
-        @param loanID uint256 The ID of the loan the collateral is for
-        @param amount uint256 The amount of collateral to be paid
+        @param loanID The ID of the loan the collateral is for
+        @param amount The amount of collateral to be paid
      */
     function _payInCollateral(uint256 loanID, uint256 amount) internal {
         // Update the total collateral and loan collateral
@@ -164,9 +164,9 @@ contract TokenCollateralLoans is LoansBase {
 
     /**
         @notice Checks to ensure the token balance matches the required balance
-        @param initialBalance uint256 The inital balance of tokens
-        @param expectedAmount uint256 The expected balance of tokens
-        @param isTransfer bool If the balance is being checked for a transfer or token allowance
+        @param initialBalance The inital balance of tokens
+        @param expectedAmount The expected balance of tokens
+        @param isTransfer If the balance is being checked for a transfer or token allowance
      */
     function _requireExpectedBalance(
         uint256 initialBalance,
@@ -191,8 +191,8 @@ contract TokenCollateralLoans is LoansBase {
 
     /**
         @notice It transfers an amount of collateral tokens to a specific address.
-        @param recipient address which will receive the tokens.
-        @param amount of tokens to transfer.
+        @param recipient The address which will receive the tokens.
+        @param amount The amount of tokens to transfer.
         @dev It throws a require error if 'transfer' invocation fails.
      */
     function collateralTokenTransfer(address recipient, uint256 amount) private {
@@ -205,8 +205,8 @@ contract TokenCollateralLoans is LoansBase {
 
     /**
         @notice It transfers an amount of collateral tokens from an address to this contract.
-        @param from address where the tokens will transfer from.
-        @param amount to be transferred.
+        @param from The address where the tokens will transfer from.
+        @param amount The amount to be transferred.
         @dev It throws a require error if the allowance is not enough.
         @dev It throws a require error if 'transferFrom' invocation fails.
      */

--- a/contracts/interfaces/LoanTermsConsensusInterface.sol
+++ b/contracts/interfaces/LoanTermsConsensusInterface.sol
@@ -11,12 +11,12 @@ import "../util/ZeroCollateralCommon.sol";
 interface LoanTermsConsensusInterface {
     /**
         @notice This event is emitted when the loan terms have been submitted
-        @param signer adddress Account address of the signatory
-        @param borrower address Account address of the borrowing party
-        @param requestNonce uint256 Nonce used for authentication of the loan request
-        @param interestRate uint256 Interest rate submitted in the loan request
-        @param collateralRatio uint256 Ratio of collateral submitted for the loan
-        @param maxLoanAmount uint256 Maximum loan amount that can be taken out
+        @param signer Account address of the signatory
+        @param borrower Account address of the borrowing party
+        @param requestNonce Nonce used for authentication of the loan request
+        @param interestRate Interest rate submitted in the loan request
+        @param collateralRatio Ratio of collateral submitted for the loan
+        @param maxLoanAmount Maximum loan amount that can be taken out
      */
     event TermsSubmitted(
         address indexed signer,
@@ -29,10 +29,10 @@ interface LoanTermsConsensusInterface {
 
     /**
         @notice This event is emitted when the loan terms have been accepted
-        @param borrower address Account address of the borrowing party
-        @param requestNonce uint256 Accepted interest rate for the loan
-        @param collateralRatio uint256 Ratio of collateral needed for the loan
-        @param maxLoanAmount uint256 Maximum loan amount that the borrower can take out
+        @param borrower Account address of the borrowing party
+        @param requestNonce Accepted interest rate for the loan
+        @param collateralRatio Ratio of collateral needed for the loan
+        @param maxLoanAmount Maximum loan amount that the borrower can take out
      */
     event TermsAccepted(
         address indexed borrower,
@@ -44,8 +44,8 @@ interface LoanTermsConsensusInterface {
 
     /**
         @notice Processes the loan request
-        @param ZeroCollateralCommon.LoanRequest request Struct of the protocol loan request
-        @param ZeroCollateralCommon.LoanResponses request List of structs of the protocol loan responses
+        @param request Struct of the protocol loan request
+        @param responses List of structs of the protocol loan responses
         @return uint256 Interest rate
         @return uint256 Collateral ratio
         @return uint256 Maximum loan amount

--- a/contracts/interfaces/LoanTermsConsensusInterface.sol
+++ b/contracts/interfaces/LoanTermsConsensusInterface.sol
@@ -3,8 +3,21 @@ pragma experimental ABIEncoderV2;
 
 import "../util/ZeroCollateralCommon.sol";
 
+/**
+    @notice This interface defines the function to process the loan terms through the Teller protocol
 
+    @author develop@teller.finance
+ */
 interface LoanTermsConsensusInterface {
+    /**
+        @notice This event is emitted when the loan terms have been submitted
+        @param signer adddress Account address of the signatory
+        @param borrower address Account address of the borrowing party
+        @param requestNonce uint256 Nonce used for authentication of the loan request
+        @param interestRate uint256 Interest rate submitted in the loan request
+        @param collateralRatio uint256 Ratio of collateral submitted for the loan
+        @param maxLoanAmount uint256 Maximum loan amount that can be taken out
+     */
     event TermsSubmitted(
         address indexed signer,
         address indexed borrower,
@@ -14,6 +27,13 @@ interface LoanTermsConsensusInterface {
         uint256 maxLoanAmount
     );
 
+    /**
+        @notice This event is emitted when the loan terms have been accepted
+        @param borrower address Account address of the borrowing party
+        @param requestNonce uint256 Accepted interest rate for the loan
+        @param collateralRatio uint256 Ratio of collateral needed for the loan
+        @param maxLoanAmount uint256 Maximum loan amount that the borrower can take out
+     */
     event TermsAccepted(
         address indexed borrower,
         uint256 indexed requestNonce,
@@ -22,6 +42,14 @@ interface LoanTermsConsensusInterface {
         uint256 maxLoanAmount
     );
 
+    /**
+        @notice Processes the loan request
+        @param ZeroCollateralCommon.LoanRequest request Struct of the protocol loan request
+        @param ZeroCollateralCommon.LoanResponses request List of structs of the protocol loan responses
+        @return uint256 Interest rate
+        @return uint256 Collateral ratio
+        @return uint256 Maximum loan amount
+     */
     function processRequest(
         ZeroCollateralCommon.LoanRequest calldata request,
         ZeroCollateralCommon.LoanResponse[] calldata responses

--- a/contracts/interfaces/LoansInterface.sol
+++ b/contracts/interfaces/LoansInterface.sol
@@ -12,9 +12,9 @@ import "../util/ZeroCollateralCommon.sol";
 interface LoansInterface {
     /**
         @notice This event is emitted when collateral has been deposited for the loan
-        @param loanId uint256 ID of the loan for which collateral was deposited
-        @param borrower address Account address of the borrower
-        @param depositAmount uint256 Amount of collateral deposited
+        @param loanID ID of the loan for which collateral was deposited
+        @param borrower Account address of the borrower
+        @param depositAmount Amount of collateral deposited
      */
     event CollateralDeposited(
         uint256 indexed loanID,
@@ -24,8 +24,8 @@ interface LoansInterface {
 
     /**
         @notice This event is emitted when collateral has been withdrawn
-        @param loanID uint256 ID of loan from which collateral was withdrawn
-        @param borrower address Account address of the borrower
+        @param loanID ID of loan from which collateral was withdrawn
+        @param borrower Account address of the borrower
      */
     event CollateralWithdrawn(
         uint256 indexed loanID,
@@ -35,12 +35,12 @@ interface LoansInterface {
 
     /**
         @notice This event is emitted when loan terms have been successsfully set
-        @param loanID uint256 ID of loan from which collateral was withdrawn
-        @param borrower address Account address of the borrower
-        @param recipient address Account address of the recipient
-        @param interestRate uint256 Interest rate set in the loan terms
-        @param collateralRatio uint256 Collateral ratio set in the loan terms
-        @param maxLoanAmount uint256 Maximum loan amount that can be taken out, set in the loan terms
+        @param loanID ID of loan from which collateral was withdrawn
+        @param borrower Account address of the borrower
+        @param recipient Account address of the recipient
+        @param interestRate Interest rate set in the loan terms
+        @param collateralRatio Collateral ratio set in the loan terms
+        @param maxLoanAmount Maximum loan amount that can be taken out, set in the loan terms
      */
     event LoanTermsSet(
         uint256 indexed loanID,
@@ -55,9 +55,9 @@ interface LoansInterface {
 
     /**
         @notice This event is emitted when a loan has been successfully taken out
-        @param loanID uint256 ID of loan from which collateral was withdrawn
-        @param borrower address Account address of the borrower
-        @param amountBorrowed uint256 Total amount taken out in the loan
+        @param loanID ID of loan from which collateral was withdrawn
+        @param borrower Account address of the borrower
+        @param amountBorrowed Total amount taken out in the loan
      */
     event LoanTakenOut(
         uint256 indexed loanID,
@@ -67,11 +67,11 @@ interface LoansInterface {
 
     /**
         @notice This event is emitted when a loan has been successfully repaid
-        @param loanID uint256 ID of loan from which collateral was withdrawn
-        @param borrower address Account address of the borrower
-        @param amountPaid uint256 Amount of the loan paid back
-        @param payer address Account address of the payer
-        @param totalOwed uint256 Total amount of the loan to be repaid
+        @param loanID ID of loan from which collateral was withdrawn
+        @param borrower Account address of the borrower
+        @param amountPaid Amount of the loan paid back
+        @param payer Account address of the payer
+        @param totalOwed Total amount of the loan to be repaid
      */
     event LoanRepaid(
         uint256 indexed loanID,
@@ -83,11 +83,11 @@ interface LoansInterface {
 
     /**
         @notice This event is emitted when a loan has been successfully liquidated
-        @param loanID uint256 ID of loan from which collateral was withdrawn
-        @param borrower address Account address of the borrower
-        @param liquidator address Account address of the liquidator
-        @param collateralOut uint256 Collateral that is sent to the liquidator
-        @param tokensIn uint256 Percentage of the collateral price paid by the liquidator to the lending pool
+        @param loanID ID of loan from which collateral was withdrawn
+        @param borrower Account address of the borrower
+        @param liquidator Account address of the liquidator
+        @param collateralOut Collateral that is sent to the liquidator
+        @param tokensIn Percentage of the collateral price paid by the liquidator to the lending pool
      */
     event LoanLiquidated(
         uint256 indexed loanID,
@@ -99,13 +99,13 @@ interface LoansInterface {
 
     /**
         @notice Returns a list of all loans for a borrower
-        @param borrower address Account address of the borrower
+        @param borrower Account address of the borrower
      */
     function getBorrowerLoans(address borrower) external view returns (uint256[] memory);
 
     /**
         @notice Returns the struct of a loan
-        @param loanID uint256 ID of loan from which collateral was withdrawn
+        @param loanID ID of loan from which collateral was withdrawn
      */
     function loans(uint256 loanID)
         external
@@ -113,10 +113,10 @@ interface LoansInterface {
         returns (ZeroCollateralCommon.Loan memory);
 
     /**
-        @param Deposit collateral for a loan, unless it isn't allowed
-        @param borrower address Account address of the borrower
-        @param loanID uint256 ID of loan from which collateral was withdrawn
-        @param amount uint256 Amount to be deposited as collateral
+        @notice Deposit collateral for a loan, unless it isn't allowed
+        @param borrower Account address of the borrower
+        @param loanID ID of loan from which collateral was withdrawn
+        @param amount Amount to be deposited as collateral
      */
     function depositCollateral(address borrower, uint256 loanID, uint256 amount)
         external
@@ -124,16 +124,16 @@ interface LoansInterface {
 
     /**
         @notice Withdraw collateral from a loan, unless this isn't allowed
-        @param amount uint256 The amount of collateral token or ether the caller is hoping to withdraw
-        @param loanID uint256 The ID of the loan the collateral is for
+        @param amount The amount of collateral token or ether the caller is hoping to withdraw
+        @param loanID The ID of the loan the collateral is for
      */
     function withdrawCollateral(uint256 amount, uint256 loanID) external;
 
     /**
         @notice Create a loan with specified terms, if allowed
-        @param ZeroCollateralCommon.LoanRequest request Struct of the protocol loan request
-        @param ZeroCollateralCommon.LoanResponses request List of structs of the protocol loan responses
-        @param collateralAmount uint256 Amount of collateral for the loan
+        @param request Struct of the protocol loan request
+        @param responses List of structs of the protocol loan responses
+        @param collateralAmount Amount of collateral for the loan
      */
     function createLoanWithTerms(
         ZeroCollateralCommon.LoanRequest calldata request,
@@ -143,21 +143,21 @@ interface LoansInterface {
 
     /**
         @notice Take out a loan, if allowed
-        @param loanID uint256 The ID of the loan to be taken out
-        @param amountBorrow uint256 Amount of tokens to be taken out in the loan
+        @param loanID The ID of the loan to be taken out
+        @param amountBorrow Amount of tokens to be taken out in the loan
      */
     function takeOutLoan(uint256 loanID, uint256 amountBorrow) external;
 
     /**
         @notice Make a payment to a specified loan
-        @param amount uint256 The amount of tokens to pay back to the loan
-        @param loanID uint256 The ID of the loan the payment is for
+        @param amount The amount of tokens to pay back to the loan
+        @param loanID The ID of the loan the payment is for
      */
     function repay(uint256 amount, uint256 loanID) external;
 
     /**
         @notice Liquidate a loan if has is expired or undercollateralised
-        @param loanID uint256 The ID of the loan to be liquidated
+        @param loanID The ID of the loan to be liquidated
      */
     function liquidateLoan(uint256 loanID) external;
 
@@ -187,7 +187,7 @@ interface LoansInterface {
 
     /**
         @notice Returns the ID of loans taken out
-        @param uint256 The next available loan ID
+        @return uint256 The next available loan ID
      */
     function loanIDCounter() external view returns (uint256);
 
@@ -199,7 +199,7 @@ interface LoansInterface {
 
     /**
         @notice Get collateral infomation of a specific loan
-        @param Loan ID of the loan to get info for
+        @param loanID ID of the loan to get info for
         @return uint256 Collateral needed
         @return uint256 Collaternal needed in Lending tokens
         @return uint256 Collateral needed in Collateral tokens

--- a/contracts/interfaces/LoansInterface.sol
+++ b/contracts/interfaces/LoansInterface.sol
@@ -1,40 +1,47 @@
-/*
-    Copyright 2020 Fabrx Labs Inc.
-
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
-*/
-
 pragma solidity 0.5.17;
 pragma experimental ABIEncoderV2;
 
 import "../util/ZeroCollateralCommon.sol";
 
+/**
+    @notice This interface defines the functions to work with the Teller loans protocol
+
+    @author develop@teller.finance
+ */
 
 interface LoansInterface {
-    // Collateral deposited by borrower
+    /**
+        @notice This event is emitted when collateral has been deposited for the loan
+        @param loanId uint256 ID of the loan for which collateral was deposited
+        @param borrower address Account address of the borrower
+        @param depositAmount uint256 Amount of collateral deposited
+     */
     event CollateralDeposited(
         uint256 indexed loanID,
         address indexed borrower,
         uint256 depositAmount
     );
 
-    // collateral withdrawn by borrower
+    /**
+        @notice This event is emitted when collateral has been withdrawn
+        @param loanID uint256 ID of loan from which collateral was withdrawn
+        @param borrower address Account address of the borrower
+     */
     event CollateralWithdrawn(
         uint256 indexed loanID,
         address indexed borrower,
         uint256 withdrawalAmount
     );
 
+    /**
+        @notice This event is emitted when loan terms have been successsfully set
+        @param loanID uint256 ID of loan from which collateral was withdrawn
+        @param borrower address Account address of the borrower
+        @param recipient address Account address of the recipient
+        @param interestRate uint256 Interest rate set in the loan terms
+        @param collateralRatio uint256 Collateral ratio set in the loan terms
+        @param maxLoanAmount uint256 Maximum loan amount that can be taken out, set in the loan terms
+     */
     event LoanTermsSet(
         uint256 indexed loanID,
         address indexed borrower,
@@ -46,13 +53,26 @@ interface LoansInterface {
         uint256 termsExpiry
     );
 
-    // new loan created
+    /**
+        @notice This event is emitted when a loan has been successfully taken out
+        @param loanID uint256 ID of loan from which collateral was withdrawn
+        @param borrower address Account address of the borrower
+        @param amountBorrowed uint256 Total amount taken out in the loan
+     */
     event LoanTakenOut(
         uint256 indexed loanID,
         address indexed borrower,
         uint256 amountBorrowed
     );
 
+    /**
+        @notice This event is emitted when a loan has been successfully repaid
+        @param loanID uint256 ID of loan from which collateral was withdrawn
+        @param borrower address Account address of the borrower
+        @param amountPaid uint256 Amount of the loan paid back
+        @param payer address Account address of the payer
+        @param totalOwed uint256 Total amount of the loan to be repaid
+     */
     event LoanRepaid(
         uint256 indexed loanID,
         address indexed borrower,
@@ -61,6 +81,14 @@ interface LoansInterface {
         uint256 totalOwed
     );
 
+    /**
+        @notice This event is emitted when a loan has been successfully liquidated
+        @param loanID uint256 ID of loan from which collateral was withdrawn
+        @param borrower address Account address of the borrower
+        @param liquidator address Account address of the liquidator
+        @param collateralOut uint256 Collateral that is sent to the liquidator
+        @param tokensIn uint256 Percentage of the collateral price paid by the liquidator to the lending pool
+     */
     event LoanLiquidated(
         uint256 indexed loanID,
         address indexed borrower,
@@ -69,43 +97,114 @@ interface LoansInterface {
         uint256 tokensIn
     );
 
+    /**
+        @notice Returns a list of all loans for a borrower
+        @param borrower address Account address of the borrower
+     */
     function getBorrowerLoans(address borrower) external view returns (uint256[] memory);
 
+    /**
+        @notice Returns the struct of a loan
+        @param loanID uint256 ID of loan from which collateral was withdrawn
+     */
     function loans(uint256 loanID)
         external
         view
         returns (ZeroCollateralCommon.Loan memory);
 
+    /**
+        @param Deposit collateral for a loan, unless it isn't allowed
+        @param borrower address Account address of the borrower
+        @param loanID uint256 ID of loan from which collateral was withdrawn
+        @param amount uint256 Amount to be deposited as collateral
+     */
     function depositCollateral(address borrower, uint256 loanID, uint256 amount)
         external
         payable;
 
+    /**
+        @notice Withdraw collateral from a loan, unless this isn't allowed
+        @param amount uint256 The amount of collateral token or ether the caller is hoping to withdraw
+        @param loanID uint256 The ID of the loan the collateral is for
+     */
     function withdrawCollateral(uint256 amount, uint256 loanID) external;
 
+    /**
+        @notice Create a loan with specified terms, if allowed
+        @param ZeroCollateralCommon.LoanRequest request Struct of the protocol loan request
+        @param ZeroCollateralCommon.LoanResponses request List of structs of the protocol loan responses
+        @param collateralAmount uint256 Amount of collateral for the loan
+     */
     function createLoanWithTerms(
         ZeroCollateralCommon.LoanRequest calldata request,
         ZeroCollateralCommon.LoanResponse[] calldata responses,
         uint256 collateralAmount
     ) external payable;
 
+    /**
+        @notice Take out a loan, if allowed
+        @param loanID uint256 The ID of the loan to be taken out
+        @param amountBorrow uint256 Amount of tokens to be taken out in the loan
+     */
     function takeOutLoan(uint256 loanID, uint256 amountBorrow) external;
 
+    /**
+        @notice Make a payment to a specified loan
+        @param amount uint256 The amount of tokens to pay back to the loan
+        @param loanID uint256 The ID of the loan the payment is for
+     */
     function repay(uint256 amount, uint256 loanID) external;
 
+    /**
+        @notice Liquidate a loan if has is expired or undercollateralised
+        @param loanID uint256 The ID of the loan to be liquidated
+     */
     function liquidateLoan(uint256 loanID) external;
 
+    /**
+        @notice Get the current price oracle
+        @return address Contract adddress of the price oracle
+     */
     function priceOracle() external view returns (address);
 
+    /**
+        @notice Returns the lending token in the lending pool
+        @return address Contract adddress of the lending pool
+     */
     function lendingPool() external view returns (address);
 
+    /**
+        @notice Returns the lending token in the lending pool
+        @return address Contract address of the lending token
+     */
     function lendingToken() external view returns (address);
 
+    /**
+        @notice Returns the total amount of collateral
+        @return uint256 The total amount of collateral held by the contract instance
+     */
     function totalCollateral() external view returns (uint256);
 
+    /**
+        @notice Returns the ID of loans taken out
+        @param uint256 The next available loan ID
+     */
     function loanIDCounter() external view returns (uint256);
 
+    /**
+        @notice Returns the collateral token
+        @return address Contract address of the token
+     */
     function collateralToken() external view returns (address);
 
+    /**
+        @notice Get collateral infomation of a specific loan
+        @param Loan ID of the loan to get info for
+        @return uint256 Collateral needed
+        @return uint256 Collaternal needed in Lending tokens
+        @return uint256 Collateral needed in Collateral tokens
+        @return bool If more collateral is needed or not
+     */
     function getCollateralInfo(uint256 loanID)
         external
         view


### PR DESCRIPTION
It includes docs for:

- LoansInterface and Implementations (Ether and Token)
- LoansBase
- LoanTermsConsensusInterface and Implementation (LoanTermConsensus)

In each contract:
- Added docs in external / public / internal functions, constructor and events. (using @ annotations).
- The contract has a header describing the purpose and @author develop@teller.finance
