### PR TITLE
[PROTOCOL-32] Validate Balance/Allowance Before Executing transfer/transferForm

### DIFF
--- a/contracts/base/LendingPool.sol
+++ b/contracts/base/LendingPool.sol
@@ -261,7 +261,7 @@ contract LendingPool is Base, LendingPoolInterface {
      */
     function tokenTransfer(address recipient, uint256 amount) private {
         uint256 currentBalance = lendingToken.balanceOf(address(this));
-          require(
+        require(
             currentBalance >= amount,
             "LENDING_TOKEN_NOT_ENOUGH_BALANCE"
           );
@@ -277,7 +277,7 @@ contract LendingPool is Base, LendingPoolInterface {
      */
     function tokenTransferFrom(address from, uint256 amount) private {
         uint256 allowance = lendingToken.allowance(from, address(this));
-          require(
+        require(
             allowance >= amount,
             "LEND_TOKEN_NOT_ENOUGH_ALLOWANCE" 
           );

--- a/contracts/base/LendingPool.sol
+++ b/contracts/base/LendingPool.sol
@@ -260,6 +260,11 @@ contract LendingPool is Base, LendingPoolInterface {
         @dev It throws a require error if 'transfer' invocation fails.
      */
     function tokenTransfer(address recipient, uint256 amount) private {
+        uint256 currentBalance = lendingToken.balanceOf(address(this));
+          require(
+            currentBalance >= amount,
+            "LENDING_TOKEN_NOT_ENOUGH_BALANCE"
+          );
         bool transferResult = lendingToken.transfer(recipient, amount);
         require(transferResult, "LENDING_TRANSFER_FAILED");
     }
@@ -271,6 +276,11 @@ contract LendingPool is Base, LendingPoolInterface {
         @dev It throws a require error if 'transferFrom' invocation fails.
      */
     function tokenTransferFrom(address from, uint256 amount) private {
+        uint256 allowance = lendingToken.allowance(from, address(this));
+          require(
+            allowance >= amount,
+            "LEND_TOKEN_NOT_ENOUGH_ALLOWANCE" 
+          );
         bool transferFromResult = lendingToken.transferFrom(from, address(this), amount);
         require(transferFromResult, "LENDING_TRANSFER_FROM_FAILED");
     }

--- a/test/base/LendingPoolCreateLoanTest.js
+++ b/test/base/LendingPoolCreateLoanTest.js
@@ -47,16 +47,18 @@ contract('LendingPoolCreateLoanTest', function (accounts) {
     });
 
     withData({
-        _1_basic: [accounts[1], loansAddress, true, 10, false, undefined, false],
-        _2_notLoanSender: [accounts[1], accounts[4], true, 10, false, 'ADDRESS_ISNT_LOANS_CONTRACT', true],
-        _3_transferFail: [accounts[1], loansAddress, false, 10, false, 'LENDING_TRANSFER_FAILED', true],
-        _4_compoundFails: [accounts[1], loansAddress, true, 10, true, 'COMPOUND_WITHDRAWAL_ERROR', true]
+        _1_basic: [accounts[1], loansAddress, true, 10, false, 1000, undefined, false],
+        _2_notLoanSender: [accounts[1], accounts[4], true, 10, false, 1000, 'ADDRESS_ISNT_LOANS_CONTRACT', true],
+        _3_transferFail: [accounts[1], loansAddress, false, 10, false, 1000, 'LENDING_TRANSFER_FAILED', true],
+        _4_compoundFails: [accounts[1], loansAddress, true, 10, true, 1000, 'COMPOUND_WITHDRAWAL_ERROR', true],
+        _5_balanceFails: [accounts[1], loansAddress, true, 10, false, 0, 'LENDING_TOKEN_NOT_ENOUGH_BALANCE', true],
     }, function(
         borrower,
         sender,
         transfer,
         amountToTransfer,
         compoundFails,
+        balanceOf,
         expectedErrorMessage,
         mustFail
     ) {
@@ -67,7 +69,10 @@ contract('LendingPoolCreateLoanTest', function (accounts) {
             
             const redeemResponse = compoundFails ? 1 : 0
             const encodeRedeemUnderlying = compoundInterfaceEncoder.encodeRedeemUnderlying();
-            await cTokenInstance.givenMethodReturnUint(encodeRedeemUnderlying, redeemResponse)
+            await cTokenInstance.givenMethodReturnUint(encodeRedeemUnderlying, redeemResponse);
+
+            const encodeBalanceOf = erc20InterfaceEncoder.encodeBalanceOf();
+            await daiInstance.givenMethodReturnUint(encodeBalanceOf, balanceOf);
             
             try {
                 // Invocation

--- a/test/base/LendingPoolDepositTest.js
+++ b/test/base/LendingPoolDepositTest.js
@@ -52,16 +52,18 @@ contract('LendingPoolDepositTest', function (accounts) {
     });
 
     withData({
-        _1_basic: [accounts[0], true, true, 1, false, undefined, false],
-        _2_notTransferFromEnoughBalance: [accounts[2], false, true, 100, false, "LENDING_TRANSFER_FROM_FAILED", true],
-        _3_notDepositIntoCompound: [accounts[2], true, true, 100, true, "COMPOUND_DEPOSIT_ERROR", true],
-        _4_notMint: [accounts[0], true, false, 60, false, 'ZTOKEN_MINT_FAILED', true],
+        _1_basic: [accounts[0], true, true, 1, false, 1000, undefined, false],
+        _2_notTransferFromEnoughBalance: [accounts[2], false, true, 100, false, 1000, "LENDING_TRANSFER_FROM_FAILED", true],
+        _3_notDepositIntoCompound: [accounts[2], true, true, 100, true, 1000, "COMPOUND_DEPOSIT_ERROR", true],
+        _4_notMint: [accounts[0], true, false, 60, false, 1000, 'ZTOKEN_MINT_FAILED', true],
+        _5_notAllowance: [accounts[0], true, true, 1, false, 0, "LEND_TOKEN_NOT_ENOUGH_ALLOWANCE", true],
     }, function(
         recipient,
         transferFrom,
         mint,
         amountToDeposit,
         compoundFails,
+        allowance,
         expectedErrorMessage,
         mustFail
     ) {
@@ -74,7 +76,10 @@ contract('LendingPoolDepositTest', function (accounts) {
 
             const mintResponse = compoundFails ? 1 : 0
             const encodeCompMint = compoundInterfaceEncoder.encodeMint();
-            await cTokenInstance.givenMethodReturnUint(encodeCompMint, mintResponse)
+            await cTokenInstance.givenMethodReturnUint(encodeCompMint, mintResponse);
+
+            const encodeAllowance = erc20InterfaceEncoder.encodeAllowance();
+            await daiInstance.givenMethodReturnUint(encodeAllowance, allowance);
 
             try {
                 // Invocation

--- a/test/base/LendingPoolLiquidationPaymentTest.js
+++ b/test/base/LendingPoolLiquidationPaymentTest.js
@@ -40,13 +40,13 @@ contract('LendingPoolLiquidationPaymentTest', function (accounts) {
     });
 
     withData({
-        _1_cTokenSupported_basic: [accounts[1], loansInstance, true, true, 10, false, undefined, false],
-        _2_cTokenSupported_transferFromFail: [accounts[1], loansInstance, true, false, 10, false, "LENDING_TRANSFER_FROM_FAILED", true],
-        _3_cTokenSupported_notLoansSender: [accounts[1], accounts[2], true, true, 71, false, 'ADDRESS_ISNT_LOANS_CONTRACT', true],
-        _4_cTokenSupported_compoundFail: [accounts[1], loansInstance, true, true, 10, true, 'COMPOUND_DEPOSIT_ERROR', true],
-        _5_cTokenNotSupported_basic: [accounts[1], loansInstance, false, true, 10, false, undefined, false],
-        _6_cTokenNotSupported_transferFromFail: [accounts[1], loansInstance, false, false, 10, false, "LENDING_TRANSFER_FROM_FAILED", true],
-        _7_cTokenNotSupported_notLoansSender: [accounts[1], accounts[2], false, true, 71, false, 'ADDRESS_ISNT_LOANS_CONTRACT', true],
+        _1_cTokenSupported_basic: [accounts[1], loansInstance, true, true, 10, false, 1000, undefined, false],
+        _2_cTokenSupported_transferFromFail: [accounts[1], loansInstance, true, false, 10, false, 1000, "LENDING_TRANSFER_FROM_FAILED", true],
+        _3_cTokenSupported_notLoansSender: [accounts[1], accounts[2], true, true, 71, false, 1000, 'ADDRESS_ISNT_LOANS_CONTRACT', true],
+        _4_cTokenSupported_compoundFail: [accounts[1], loansInstance, true, true, 10, true, 1000, 'COMPOUND_DEPOSIT_ERROR', true],
+        _5_cTokenNotSupported_basic: [accounts[1], loansInstance, false, true, 10, false, 1000, undefined, false],
+        _6_cTokenNotSupported_transferFromFail: [accounts[1], loansInstance, false, false, 10, false, 1000, "LENDING_TRANSFER_FROM_FAILED", true],
+        _7_cTokenNotSupported_notLoansSender: [accounts[1], accounts[2], false, true, 71, false, 1000, 'ADDRESS_ISNT_LOANS_CONTRACT', true],
     }, function(
         liquidator,
         sender,
@@ -54,6 +54,7 @@ contract('LendingPoolLiquidationPaymentTest', function (accounts) {
         transferFrom,
         amountToLiquidate,
         compoundFails,
+        allowance,
         expectedErrorMessage,
         mustFail
     ) {
@@ -73,7 +74,9 @@ contract('LendingPoolLiquidationPaymentTest', function (accounts) {
 
             const redeemResponse = compoundFails ? 1 : 0
             const encodeMint = compoundInterfaceEncoder.encodeMint();
-            await cTokenInstance.givenMethodReturnUint(encodeMint, redeemResponse)
+            await cTokenInstance.givenMethodReturnUint(encodeMint, redeemResponse);
+            const encodeAllowance = erc20InterfaceEncoder.encodeAllowance();
+            await daiInstance.givenMethodReturnUint(encodeAllowance, allowance);
 
             try {
                 // Invocation

--- a/test/base/LendingPoolRepayTest.js
+++ b/test/base/LendingPoolRepayTest.js
@@ -41,13 +41,13 @@ contract('LendingPoolRepayTest', function (accounts) {
     });
 
     withData({
-        _1_cTokenSupported_basic: [accounts[1], loansAddress, true, true, 10, false, undefined, false],
-        _2_cTokenSupported_notLoan: [accounts[1], accounts[2], true, true, 10, false, 'ADDRESS_ISNT_LOANS_CONTRACT', true],
-        _3_cTokenSupported_transferFail: [accounts[1], loansAddress, true, false, 200, false, "LENDING_TRANSFER_FROM_FAILED", true],
-        _4_cTokenSupported_compoundFail: [accounts[1], loansAddress, true, true, 10, true, 'COMPOUND_DEPOSIT_ERROR', true],
-        _6_cTokenNotSupported_basic: [accounts[1], loansAddress, false, true, 10, false, undefined, false],
-        _7_cTokenNotSupported_notLoan: [accounts[1], accounts[2], false, true, 10, false, 'ADDRESS_ISNT_LOANS_CONTRACT', true],
-        _8_cTokenNotSupported_transferFail: [accounts[1], loansAddress, false, false, 200, false, "LENDING_TRANSFER_FROM_FAILED", true],
+        _1_cTokenSupported_basic: [accounts[1], loansAddress, true, true, 10, false, 1000, undefined, false],
+        _2_cTokenSupported_notLoan: [accounts[1], accounts[2], true, true, 10, false, 1000, 'ADDRESS_ISNT_LOANS_CONTRACT', true],
+        _3_cTokenSupported_transferFail: [accounts[1], loansAddress, true, false, 200, false, 1000, "LENDING_TRANSFER_FROM_FAILED", true],
+        _4_cTokenSupported_compoundFail: [accounts[1], loansAddress, true, true, 10, true, 1000, 'COMPOUND_DEPOSIT_ERROR', true],
+        _6_cTokenNotSupported_basic: [accounts[1], loansAddress, false, true, 10, false, 1000, undefined, false],
+        _7_cTokenNotSupported_notLoan: [accounts[1], accounts[2], false, true, 10, false, 1000, 'ADDRESS_ISNT_LOANS_CONTRACT', true],
+        _8_cTokenNotSupported_transferFail: [accounts[1], loansAddress, false, false, 200, false, 1000, "LENDING_TRANSFER_FROM_FAILED", true],
     }, function(
         borrower,
         sender,
@@ -55,6 +55,7 @@ contract('LendingPoolRepayTest', function (accounts) {
         transferFrom,
         amountToRepay,
         compoundFails,
+        allowance,
         expectedErrorMessage,
         mustFail
     ) {
@@ -74,7 +75,10 @@ contract('LendingPoolRepayTest', function (accounts) {
             
             const mintResponse = compoundFails ? 1 : 0
             const encodeCompMint = compoundInterfaceEncoder.encodeMint();
-            await cTokenInstance.givenMethodReturnUint(encodeCompMint, mintResponse)
+            await cTokenInstance.givenMethodReturnUint(encodeCompMint, mintResponse);
+
+            const encodeAllowance = erc20InterfaceEncoder.encodeAllowance();
+            await daiInstance.givenMethodReturnUint(encodeAllowance, allowance);
             
             try {
                 // Invocation

--- a/test/base/LendingPoolRepayTest.js
+++ b/test/base/LendingPoolRepayTest.js
@@ -48,6 +48,7 @@ contract('LendingPoolRepayTest', function (accounts) {
         _6_cTokenNotSupported_basic: [accounts[1], loansAddress, false, true, 10, false, 1000, undefined, false],
         _7_cTokenNotSupported_notLoan: [accounts[1], accounts[2], false, true, 10, false, 1000, 'ADDRESS_ISNT_LOANS_CONTRACT', true],
         _8_cTokenNotSupported_transferFail: [accounts[1], loansAddress, false, false, 200, false, 1000, "LENDING_TRANSFER_FROM_FAILED", true],
+        _9_cTokenNotSupported_allowanceFail: [accounts[1], loansAddress, false, true, 10, false, 0, "LEND_TOKEN_NOT_ENOUGH_ALLOWANCE", true],
     }, function(
         borrower,
         sender,

--- a/test/base/LendingPoolWithdrawTest.js
+++ b/test/base/LendingPoolWithdrawTest.js
@@ -5,6 +5,7 @@ const { lendingPool } = require('../utils/events');
 const { initContracts } = require('../utils/contracts');
 const BurnableInterfaceEncoder = require('../utils/encoders/BurnableInterfaceEncoder');
 const CompoundInterfaceEncoder = require('../utils/encoders/CompoundInterfaceEncoder');
+const ERC20InterfaceEncoder = require('../utils/encoders/ERC20InterfaceEncoder');
 
 // Mock contracts
 const Mock = artifacts.require("./mock/util/Mock.sol");
@@ -18,6 +19,7 @@ const ZDai = artifacts.require("./base/ZDAI.sol");
 contract('LendingPoolWithdrawTest', function (accounts) {
     const burnableInterfaceEncoder = new BurnableInterfaceEncoder(web3);
     const compoundInterfaceEncoder = new CompoundInterfaceEncoder(web3);
+    const erc20InterfaceEncoder = new ERC20InterfaceEncoder(web3);
     let instance;
     let loansInstance;
     let consensusInstance;
@@ -33,14 +35,15 @@ contract('LendingPoolWithdrawTest', function (accounts) {
     });
 
     withData({
-        _1_basic: [accounts[0], true, 10, false, undefined, false],
-        _2_transferFail: [accounts[1], false, 50, false, 'LENDING_TRANSFER_FAILED', true],
-        _3_compoundFail: [accounts[1], true, 50, true, 'COMPOUND_WITHDRAWAL_ERROR', true],
+        _1_basic: [accounts[0], true, 10, false, 1000, undefined, false],
+        _2_transferFail: [accounts[1], false, 50, false, 1000, 'LENDING_TRANSFER_FAILED', true],
+        _3_compoundFail: [accounts[1], true, 50, true, 1000, 'COMPOUND_WITHDRAWAL_ERROR', true],
     }, function(
         recipient,
         transfer,
         amountToWithdraw,
         compoundFails,
+        balanceOf,
         expectedErrorMessage,
         mustFail
     ) {
@@ -54,7 +57,10 @@ contract('LendingPoolWithdrawTest', function (accounts) {
 
             const redeemResponse = compoundFails ? 1 : 0
             const encodeRedeemUnderlying = compoundInterfaceEncoder.encodeRedeemUnderlying();
-            await cTokenInstance.givenMethodReturnUint(encodeRedeemUnderlying, redeemResponse)
+            await cTokenInstance.givenMethodReturnUint(encodeRedeemUnderlying, redeemResponse);
+
+            const encodeBalanceOf = erc20InterfaceEncoder.encodeBalanceOf();
+            await lendingTokenInstance.givenMethodReturnUint(encodeBalanceOf, balanceOf);
 
             try {
                 // Invocation

--- a/test/base/LendingPoolWithdrawTest.js
+++ b/test/base/LendingPoolWithdrawTest.js
@@ -38,6 +38,7 @@ contract('LendingPoolWithdrawTest', function (accounts) {
         _1_basic: [accounts[0], true, 10, false, 1000, undefined, false],
         _2_transferFail: [accounts[1], false, 50, false, 1000, 'LENDING_TRANSFER_FAILED', true],
         _3_compoundFail: [accounts[1], true, 50, true, 1000, 'COMPOUND_WITHDRAWAL_ERROR', true],
+        _4_balanceFail: [accounts[0], true, 10, false, 0, 'LENDING_TOKEN_NOT_ENOUGH_BALANCE', true],
     }, function(
         recipient,
         transfer,


### PR DESCRIPTION
It is:
- To verify whether the contract has enough balance or allowance and display user-friendly error messages to the final user instead, of non-readable error messages

It includes:
- "require" lending token balance validation in the tokenTransfer function in LendingPool.sol
- "require" lending token allowance validation in the tokenTransferFrom function in LendingPool.sol
- Unit test for new changes

<img width="728" alt="Screen Shot 2020-07-27 at 4 27 37 PM" src="https://user-images.githubusercontent.com/17607777/88588941-5d3f8500-d026-11ea-9a4f-f34b99557235.png">
