### PR TITLE
[PROTOCOL-33] Create Signature library

### DIFF
--- a/contracts/mock/base/InterestConsensusMock.sol
+++ b/contracts/mock/base/InterestConsensusMock.sol
@@ -56,13 +56,13 @@ contract InterestConsensusMock is InterestConsensus {
         ZeroCollateralCommon.InterestResponse calldata response,
         bytes32 requestHash
     ) external view returns (bytes32) {
-        return _hashResponse(response, requestHash);
+        return SignatureLib.hashInterestResponse(response, requestHash, _getChainId());
     }
 
     function externalHashRequest(
         ZeroCollateralCommon.InterestRequest calldata request
     ) external view returns (bytes32) {
-        return _hashRequest(request);
+        return SignatureLib.hashInterestRequest(request, callerAddress, _getChainId());
     }
 
     function _getChainId() internal view returns (uint256) {

--- a/contracts/mock/base/LoanTermsConsensusMock.sol
+++ b/contracts/mock/base/LoanTermsConsensusMock.sol
@@ -96,13 +96,13 @@ contract LoanTermsConsensusMock is LoanTermsConsensus {
         ZeroCollateralCommon.LoanResponse calldata response,
         bytes32 requestHash
     ) external view returns (bytes32) {
-        return _hashResponse(response, requestHash);
+        return SignatureLib.hashLoanTermsResponse(response, requestHash, _getChainId());
     }
 
     function externalHashRequest(
         ZeroCollateralCommon.LoanRequest calldata request
     ) external view returns (bytes32) {
-        return _hashRequest(request);
+        return SignatureLib.hashLoanTermsRequest(request, callerAddress, _getChainId());
     }
 
     function _getChainId() internal view returns (uint256) {

--- a/contracts/util/SignatureLib.sol
+++ b/contracts/util/SignatureLib.sol
@@ -1,0 +1,122 @@
+pragma solidity 0.5.17;
+
+// Libraries
+import "../util/NumbersList.sol";
+import "../util/ZeroCollateralCommon.sol";
+
+/**
+ * @dev Signature library of hash functions for loan responses and requests
+ *
+ * @author develop@teller.finance
+ */
+
+ library SignatureLib {
+     using SafeMath for uint256;
+    /**
+        @notice Generates a hash for the loan response
+        @param response Structs of the protocol loan responses
+        @param requestHash Hash of the loan request
+        @return bytes32 Hash of the loan response
+     */
+    function hashLoanTermsResponse(
+        ZeroCollateralCommon.LoanResponse memory response,
+        bytes32 requestHash,
+        uint256 chainId
+    ) internal view returns (bytes32) {
+        return
+            keccak256(
+                abi.encode(
+                    response.consensusAddress,
+                    response.responseTime,
+                    response.interestRate,
+                    response.collateralRatio,
+                    response.maxLoanAmount,
+                    response.signature.signerNonce,
+                    chainId,
+                    requestHash
+                )
+            );
+    }
+
+    /**
+        @notice Generates a hash for the loan request
+        @param request Struct of the protocol loan request
+        @return bytes32 Hash of the loan request
+     */
+    function hashLoanTermsRequest(
+        ZeroCollateralCommon.LoanRequest memory request,
+        address callerAddress,
+        uint256 chainId
+        )
+        internal
+        view
+        returns (bytes32)
+    {
+        return
+            keccak256(
+                abi.encode(
+                    callerAddress,
+                    request.borrower,
+                    request.recipient,
+                    request.consensusAddress,
+                    request.requestNonce,
+                    request.amount,
+                    request.duration,
+                    request.requestTime,
+                    chainId
+                )
+            );
+    }
+
+    /**
+        @notice It creates a hash based on a node response and lender request.
+        @param response a node response.
+        @param requestHash a hash value that represents the lender request.
+        @return a hash value.
+     */
+    function hashInterestResponse(
+        ZeroCollateralCommon.InterestResponse memory response,
+        bytes32 requestHash,
+        uint256 chainId
+    ) internal view returns (bytes32) {
+        return
+            keccak256(
+                abi.encode(
+                    response.consensusAddress,
+                    response.responseTime,
+                    response.interest,
+                    response.signature.signerNonce,
+                    chainId,
+                    requestHash
+                )
+            );
+    }
+
+    /**
+        @notice It creates a hash value based on the lender request.
+        @param request the interest request sent by the lender.
+        @return a hash value.
+     */
+    function hashInterestRequest(
+        ZeroCollateralCommon.InterestRequest memory request,
+        address callerAddress,
+        uint256 chainId
+        )
+        internal
+        view
+        returns (bytes32)
+    {
+        return
+            keccak256(
+                abi.encode(
+                    callerAddress,
+                    request.lender,
+                    request.consensusAddress,
+                    request.startTime,
+                    request.endTime,
+                    request.requestTime,
+                    chainId
+                )
+            );
+    }
+ }

--- a/contracts/util/SignatureLib.sol
+++ b/contracts/util/SignatureLib.sol
@@ -16,6 +16,7 @@ import "../util/ZeroCollateralCommon.sol";
         @notice Generates a hash for the loan response
         @param response Structs of the protocol loan responses
         @param requestHash Hash of the loan request
+        @param chainId Current chain id
         @return bytes32 Hash of the loan response
      */
     function hashLoanTermsResponse(
@@ -41,6 +42,8 @@ import "../util/ZeroCollateralCommon.sol";
     /**
         @notice Generates a hash for the loan request
         @param request Struct of the protocol loan request
+        @param callerAddress Address of the caller
+        @param chainId Current chain id
         @return bytes32 Hash of the loan request
      */
     function hashLoanTermsRequest(
@@ -72,6 +75,7 @@ import "../util/ZeroCollateralCommon.sol";
         @notice It creates a hash based on a node response and lender request.
         @param response a node response.
         @param requestHash a hash value that represents the lender request.
+        @param chainId Current chain id
         @return a hash value.
      */
     function hashInterestResponse(
@@ -95,6 +99,8 @@ import "../util/ZeroCollateralCommon.sol";
     /**
         @notice It creates a hash value based on the lender request.
         @param request the interest request sent by the lender.
+        @param callerAddress Address of the caller
+        @param chainId Current chain id
         @return a hash value.
      */
     function hashInterestRequest(

--- a/test/base/LoanTermsConsensusHashesTest.js
+++ b/test/base/LoanTermsConsensusHashesTest.js
@@ -27,7 +27,7 @@ contract('LoanTermsConsensus hashRequest and hashReponse', function (accounts) {
 
     withData({
         _1_mainnet_first_test_hashRequest: [chains.mainnet, accounts[2], accounts[1], 234764, 344673177, 34467317723, 234534],
-        _2_ropsten_test_hashRequest: [chains.ropsten, accounts[3], accounts[4], 254864, 345673177, 34467317723, 234534],
+        _2_ropsten_test_hashRequest: [chains.rinkeby, accounts[3], accounts[4], 254864, 345673177, 34467317723, 234534],
         _3_second_test_hashRequest: [chains.mainnet, NULL_ADDRESS, NULL_ADDRESS, 0, 0, 0, 0],
     }, function(
         chainId,

--- a/test/base/LoanTermsConsensusHashesTest.js
+++ b/test/base/LoanTermsConsensusHashesTest.js
@@ -27,7 +27,7 @@ contract('LoanTermsConsensus hashRequest and hashReponse', function (accounts) {
 
     withData({
         _1_mainnet_first_test_hashRequest: [chains.mainnet, accounts[2], accounts[1], 234764, 344673177, 34467317723, 234534],
-        _2_ropsten_test_hashRequest: [chains.rinkeby, accounts[3], accounts[4], 254864, 345673177, 34467317723, 234534],
+        _2_ropsten_test_hashRequest: [chains.ropsten, accounts[3], accounts[4], 254864, 345673177, 34467317723, 234534],
         _3_second_test_hashRequest: [chains.mainnet, NULL_ADDRESS, NULL_ADDRESS, 0, 0, 0, 0],
     }, function(
         chainId,


### PR DESCRIPTION
It is:
- A reusable Signature library that can be used in contracts by importing and using the statement 'using SignatureLib for XXX'

It includes:
- SignatureLib.sol Library 
- --hashLoanTermsRequest and hashLoanTermsResponse functions for use in contracts like LoanTermsConsensus.sol
- --hashInterestRequest and hashInterestResponse functions for use in contracts such as InterestConsensus.sol
- Changes to integrate the library into LoanTermsConsensus, LoanTermConsensusMock, InterestConsensus & InterestConsensusMock

<img width="745" alt="Screen Shot 2020-07-27 at 11 35 33 PM" src="https://user-images.githubusercontent.com/17607777/88616828-23d93a80-d063-11ea-9625-d412edd9d889.png">
