### PR TITLE
[PROTOCOL-33] Create Signature library

### DIFF
--- a/contracts/mock/util/SignatureLibMock.sol
+++ b/contracts/mock/util/SignatureLibMock.sol
@@ -1,0 +1,96 @@
+pragma solidity 0.5.17;
+pragma experimental ABIEncoderV2;
+
+import "../../util/SignatureLib.sol";
+
+contract SignatureLibMock {
+    using SafeMath for uint256;
+    using SignatureLib for SignatureLib.Signature;
+
+    SignatureLib.Signature public signature;
+
+    uint256 private _mockChainId = 1; // Mainnet
+
+    function _getChainId() internal view returns (uint256) {
+        return _mockChainId;
+    }
+
+    function mockChainId(uint256 newChainId) external {
+        _mockChainId = newChainId;
+    }
+
+    function setInterestReqHash(
+        ZeroCollateralCommon.InterestRequest memory request,
+        address callerAddress
+        )
+        public
+    {
+        signature.setInterestRequestHash(request, callerAddress, _mockChainId);
+    }
+
+    function getHashedInterestRequest(
+        ZeroCollateralCommon.InterestRequest memory request
+        )
+        public
+        view
+        returns (bytes32)
+    {
+        return signature.hashInterestRequest(request);
+    }
+
+    function setHashInterestResponse(
+        ZeroCollateralCommon.InterestResponse memory response
+        )
+        public
+    {
+        signature.setHashInterestResponse(response);
+    }
+
+    function getHashInterestResponse(
+        ZeroCollateralCommon.InterestResponse memory response
+        )
+        public
+        view
+        returns (bytes32)
+    {
+        return signature.responseHash;
+    }
+
+    function setLoanRequestHash(
+        ZeroCollateralCommon.LoanRequest memory request,
+        address callerAddress
+        )
+        public
+    {
+        signature.setLoanRequestHash(request, callerAddress, _mockChainId);
+    }
+
+    function getHashedLoanRequest(
+        ZeroCollateralCommon.LoanRequest memory request
+        )
+        public
+        view
+        returns (bytes32)
+    {
+        return signature.hashLoanRequest(request);
+    }
+
+    function setHashLoanResponse(
+        ZeroCollateralCommon.LoanResponse memory response
+        )
+        public
+    {
+        signature.setHashLoanResponse(response);
+    }
+
+    function getHashedLoanResponse(
+        ZeroCollateralCommon.LoanResponse memory response
+        )
+        public
+        view
+        returns (bytes32)
+    {
+        return signature.hashLoanResponse(response);
+    }
+
+}

--- a/contracts/util/SignatureLib.sol
+++ b/contracts/util/SignatureLib.sol
@@ -1,0 +1,190 @@
+pragma solidity 0.5.17;
+
+// Libraries
+import "./ZeroCollateralCommon.sol";
+
+
+/**
+ * @dev Signature library of hash functions for interest and loans, responses and requests
+ *
+ * @author develop@teller.finance
+ */
+
+library SignatureLib {
+
+    struct Signature {
+       bytes32 responseHash;
+       bytes32 requestHash;
+       address callerAddress;
+       uint256 chainId;
+    }
+
+    /**
+        @notice Stores a hash for the interest request in the struct
+        @param self current signature struct
+     */
+    function setInterestRequestHash(
+        Signature storage self,
+        ZeroCollateralCommon.InterestRequest memory request,
+        address callerAddress,
+        uint256 chainId
+        )
+        internal
+    {
+            self.chainId = chainId;
+            self.callerAddress = callerAddress;
+            self.requestHash = hashInterestRequest(self, request);
+    }
+
+    /**
+        @notice It creates a hash value based on the lender request.
+        @param self current signature struct
+        @return a hash value.
+     */
+    function hashInterestRequest(
+        Signature storage self,
+        ZeroCollateralCommon.InterestRequest memory request
+        )
+        internal
+        view
+        returns (bytes32)
+    {
+        return keccak256(
+                abi.encode(
+                    self.callerAddress,
+                    request.lender,
+                    request.consensusAddress,
+                    request.requestNonce,
+                    request.startTime,
+                    request.endTime,
+                    request.requestTime,
+                    self.chainId
+                )
+            );
+    }
+
+    /**
+        @notice It stores a hash based on a node response and lender request.
+        @param self current signature struct
+        @return a hash value.
+     */
+    function setHashInterestResponse(
+        Signature storage self,
+        ZeroCollateralCommon.InterestResponse memory response
+        )
+        internal
+    {
+        self.responseHash = hashInterestResponse(self, response);
+
+    }
+
+    /**
+        @notice It creates a hash based on a node response and lender request.
+        @param self current signature struct
+        @return a hash value.
+     */
+    function hashInterestResponse(
+        Signature storage self,
+        ZeroCollateralCommon.InterestResponse memory response
+    ) internal
+      view
+      returns (bytes32)
+    {
+        return
+            keccak256(
+                abi.encode(
+                    response.consensusAddress,
+                    response.responseTime,
+                    response.interest,
+                    response.signature.signerNonce,
+                    self.chainId,
+                    self.requestHash
+                )
+            );
+    }
+
+    /**
+        @notice Stores a hash for the loan request in the struct
+        @param self current signature struct
+     */
+    function setLoanRequestHash(
+        Signature storage self,
+        ZeroCollateralCommon.LoanRequest memory request,
+        address callerAddress,
+        uint256 chainId
+        )
+        internal
+    {
+            self.chainId = chainId;
+            self.callerAddress = callerAddress;
+            self.requestHash = hashLoanRequest(self, request);
+    }
+
+    /**
+        @notice Generates a hash for the loan request
+        @param self current signature struct
+        @return bytes32 Hash of the loan request
+     */
+    function hashLoanRequest(
+        Signature storage self,
+        ZeroCollateralCommon.LoanRequest memory request
+        )
+        internal
+        view
+        returns (bytes32)
+    {
+        return keccak256(
+                abi.encode(
+                    self.callerAddress,
+                    request.borrower,
+                    request.recipient,
+                    request.consensusAddress,
+                    request.requestNonce,
+                    request.amount,
+                    request.duration,
+                    request.requestTime,
+                    self.chainId
+                )
+            );
+    }
+
+    /**
+        @notice It stores a hash based on a node response and loan request.
+        @param self current signature struct
+        @return a hash value.
+     */
+    function setHashLoanResponse(
+        Signature storage self,
+        ZeroCollateralCommon.LoanResponse memory response
+    ) internal
+    {
+        self.responseHash = hashLoanResponse(self, response);
+
+    }
+
+    /**
+        @notice Generates a hash for the loan response
+        @param self current signature struct
+        @return bytes32 Hash of the loan response
+     */
+    function hashLoanResponse(
+        Signature storage self,
+        ZeroCollateralCommon.LoanResponse memory response
+    ) internal
+      view
+      returns (bytes32)
+    {
+        return keccak256(
+                abi.encode(
+                    response.consensusAddress,
+                    response.responseTime,
+                    response.interestRate,
+                    response.collateralRatio,
+                    response.maxLoanAmount,
+                    response.signature.signerNonce,
+                    self.chainId,
+                    self.requestHash
+                )
+            );
+    }
+ }

--- a/package.json
+++ b/package.json
@@ -50,8 +50,9 @@
   },
   "dependencies": {
     "@chainlink/contracts": "^0.0.5",
-    "bignumber.js": "^9.0.0",
     "@openzeppelin/contracts": "2.5.1",
+    "bignumber.js": "^9.0.0",
+    "elliptic": "^6.5.3",
     "truffle-hdwallet-provider": "^1.0.17",
     "web3": "1.0.0-beta.55",
     "web3-provider-engine": "15.0.0",

--- a/test/util/SignatureLibHashInterestRequestTest.js
+++ b/test/util/SignatureLibHashInterestRequestTest.js
@@ -1,0 +1,98 @@
+// JS Libraries
+const withData = require('leche').withData;
+const { t } = require('../utils/consts');
+const { hashInterestRequest, hashInterestResponse } = require('../utils/hashes');
+const { createInterestRequest, createUnsignedInterestResponse } = require('../utils/structs');
+const ethUtil = require('ethereumjs-util')
+
+// Smart contracts
+const SignatureLibMock = artifacts.require("./mock/util/SignatureLibMock.sol");
+
+// constants
+const { NULL_ADDRESS } = require('../utils/consts');
+const chains = require('../utils/chains');
+
+contract('SignatureLibHashInterestRequestTest', function (accounts) {
+    const lendersAddress = accounts[3];
+    let instance;
+
+    beforeEach('Setup for each test', async () => {
+        instance = await SignatureLibMock.new();
+    });
+
+    withData({
+        _1_mainnet_test_hashInterestRequest: [chains.mainnet, 1, accounts[2], 234764, 344673177, 34467317723],
+        _2_ropsten_first_test_hashInterestRequest: [chains.ropsten, 2,  accounts[3], 134764, 354673177, 37467617723],
+        _3_ropsten_second_test_hashInterestRequest: [chains.ropsten, 3, NULL_ADDRESS, 0, 0, 0],
+    }, function(
+            chainId,
+            requestNonce,
+            lender,
+            startTime,
+            endTime,
+            requestTime,
+        ) {
+        it(t('user', 'addSignature', 'Should be able to hash a request and response', false), async function() {
+            const request = createInterestRequest(lender, requestNonce, startTime, endTime, requestTime, instance.address, chains.mainnet);
+
+            let expectedResult = ethUtil.bufferToHex(
+                hashInterestRequest(
+                    request,
+                    lendersAddress,
+                    chainId,
+                )
+            )
+
+            // Get hash
+            await instance.mockChainId(chainId)
+            await instance.setInterestReqHash(request, lendersAddress);
+            const result = await instance.getHashedInterestRequest(request);
+
+            assert.equal(
+                result,
+                expectedResult,
+                'Result should habe been ' + expectedResult
+            );
+
+        });
+    });
+
+    withData({
+        _4_mainnet_test_hashInterestResponse: [chains.mainnet, 4, accounts[0], 234764, 344673177, 34467317723],
+        _5_ropsten_first_test_hashInterestResponse: [chains.ropsten, 5, accounts[4], 765189, 344673177, 34657317723],
+        _6_ropsten_second_test_hashInterestResponse: [chains.mainnet, 6, NULL_ADDRESS, 0, 0, 0],
+    }, function(
+        chainId,
+        requestNonce,
+        signer,
+        responseTime,
+        interest,
+        signerNonce,
+    ) {    
+        it(t('user', 'new', 'Should correctly calculate the hash for a response', false), async function() {
+            const request = createInterestRequest(accounts[3], requestNonce, 2345, 2345, 3456, instance.address)
+            const requestHash = ethUtil.bufferToHex(hashInterestRequest(request, accounts[4], chainId))
+            const response = createUnsignedInterestResponse(signer, responseTime, interest, signerNonce, instance.address)
+
+            const expectedHash = ethUtil.bufferToHex(
+                hashInterestResponse(
+                    response,
+                    requestHash,
+                    chainId,
+                )
+            )
+
+            // Invocation
+            await instance.mockChainId(chainId);
+            await instance.setInterestReqHash(request, accounts[4]);
+            await instance.setHashInterestResponse(response);
+            const result = await instance.getHashInterestResponse(response);
+
+            assert.equal(
+                result,
+                expectedHash,
+                'Result should have been ' + expectedHash
+                );
+        });
+    });
+});

--- a/test/util/SignatureLibHashLoanRequestTest.js
+++ b/test/util/SignatureLibHashLoanRequestTest.js
@@ -1,0 +1,100 @@
+// JS Libraries
+const withData = require('leche').withData;
+const { t } = require('../utils/consts');
+const { hashLoanTermsRequest, hashLoanTermsResponse } = require('../utils/hashes');
+const { createLoanRequest, createUnsignedLoanResponse } = require('../utils/structs');
+const ethUtil = require('ethereumjs-util')
+
+// Smart contracts
+const Mock = artifacts.require("./mock/util/Mock.sol");
+const SignatureLibMock = artifacts.require("./mock/util/SignatureLibMock.sol");
+
+// constants
+const { NULL_ADDRESS } = require('../utils/consts');
+const chains = require('../utils/chains');
+
+contract('SignatureLibHashLoanRequestTest', function (accounts) {
+    const loansAddress = accounts[4];
+    let consensusInstance;
+    let instance;
+
+    beforeEach('Setup for each test', async () => {
+        instance = await SignatureLibMock.new();
+        consensusInstance = await Mock.new();
+    });
+
+    withData({
+        _1_mainnet_first_test_hashLoanRequest: [chains.mainnet, accounts[2], accounts[1], 234764, 344673177, 34467317723, 234534],
+        _2_ropsten_test_hashLoanRequest: [chains.ropsten, accounts[3], accounts[4], 254864, 345673177, 34467317723, 234534],
+        _3_mainnet_second_test_hashLoanRequest: [chains.mainnet, NULL_ADDRESS, NULL_ADDRESS, 0, 0, 0, 0],
+    }, function(
+        chainId,
+        borrower,
+        recipient,
+        requestNonce,
+        amount,
+        duration,
+        requestTime,
+    ) {    
+        it(t('user', 'hashRequest', 'Should correctly calculate the hash for a request', false), async function() {
+            const request = createLoanRequest(borrower, recipient, requestNonce, amount, duration, requestTime, instance.address)
+            let expectedResult = ethUtil.bufferToHex(
+                hashLoanTermsRequest(
+                    request,
+                    loansAddress,
+                    chainId,
+                )
+            );
+
+            // Invocation
+            await instance.mockChainId(chainId);
+            await instance.setLoanRequestHash(request, loansAddress);
+            const result = await instance.getHashedLoanRequest(request);
+
+            assert.equal(
+                result,
+                expectedResult,
+                'Result should have been ' + expectedResult
+                );
+        });
+    });
+
+    withData({
+        _4_mainnet_first_test_hashResponse: [chains.mainnet, accounts[2], 34552, 234764, 344673177, 34467317723, 345345, 34],
+        _5_mainnet_second_test_hashResponse: [chains.mainnet, NULL_ADDRESS, 0, 0, 0, 0, 0],
+    }, function(
+        chainId,
+        signer,
+        responseTime,
+        interestRate,
+        collateralRatio,
+        maxLoanAmount,
+        signerNonce,
+    ) {    
+        it(t('user', 'hashResponse', 'Should correctly calculate the hash for a response', false), async function() {
+            const response = createUnsignedLoanResponse(signer, responseTime, interestRate, collateralRatio, maxLoanAmount, signerNonce, instance.address)
+            const request = createLoanRequest(NULL_ADDRESS, NULL_ADDRESS, 52345, 2345234, 234534, 34534, consensusInstance.address)
+            const requestHash = ethUtil.bufferToHex(hashLoanTermsRequest(request, accounts[4], chainId))
+
+            const expectedHash = ethUtil.bufferToHex(
+                hashLoanTermsResponse(
+                    response,
+                    requestHash,
+                    chainId,
+                )
+            )
+
+            // Invocation
+            await instance.mockChainId(chainId);
+            await instance.setLoanRequestHash(request, loansAddress);
+            await instance.setHashLoanResponse(response);
+            const result = await instance.getHashedLoanResponse(response);
+
+            assert.equal(
+                result,
+                expectedHash,
+                'Result should have been ' + expectedHash
+                );
+        });
+    });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -2310,6 +2310,19 @@ elliptic@6.5.2, elliptic@^6.0.0, elliptic@^6.4.0, elliptic@^6.5.2:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.0"
 
+elliptic@^6.5.3:
+  version "6.5.3"
+  resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.5.3.tgz#cb59eb2efdaf73a0bd78ccd7015a62ad6e0f93d6"
+  integrity sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==
+  dependencies:
+    bn.js "^4.4.0"
+    brorand "^1.0.1"
+    hash.js "^1.0.0"
+    hmac-drbg "^1.0.0"
+    inherits "^2.0.1"
+    minimalistic-assert "^1.0.0"
+    minimalistic-crypto-utils "^1.0.0"
+
 emoji-regex@^7.0.1:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-7.0.3.tgz#933a04052860c85e83c122479c4748a8e4c72156"


### PR DESCRIPTION
It is:
- A reusable Signature library based on functions built in the InterestConsensus and LoanTermsConsensus contracts

It includes:
- New signature library & mock contract for Interest and LoanTerms
- New unit tests 

Included PROTOCOL-104
- Upgraded elliptic@^6.5.3 to address the Dependabot alert

<img width="703" alt="Screen Shot 2020-08-04 at 11 39 14 PM" src="https://user-images.githubusercontent.com/17607777/89371294-f3238180-d6b0-11ea-9b63-c4dbb8c81977.png">


[PROTOCOL-33]: https://teller-finance.atlassian.net/browse/PROTOCOL-33