### PR TITLE
[PROTOCOL-104] Contracts Repo: Fix Github Alert

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,8 +50,9 @@
   },
   "dependencies": {
     "@chainlink/contracts": "^0.0.5",
-    "bignumber.js": "^9.0.0",
     "@openzeppelin/contracts": "2.5.1",
+    "bignumber.js": "^9.0.0",
+    "elliptic": "^6.5.3",
     "truffle-hdwallet-provider": "^1.0.17",
     "web3": "1.0.0-beta.55",
     "web3-provider-engine": "15.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2310,6 +2310,19 @@ elliptic@6.5.2, elliptic@^6.0.0, elliptic@^6.4.0, elliptic@^6.5.2:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.0"
 
+elliptic@^6.5.3:
+  version "6.5.3"
+  resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.5.3.tgz#cb59eb2efdaf73a0bd78ccd7015a62ad6e0f93d6"
+  integrity sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==
+  dependencies:
+    bn.js "^4.4.0"
+    brorand "^1.0.1"
+    hash.js "^1.0.0"
+    hmac-drbg "^1.0.0"
+    inherits "^2.0.1"
+    minimalistic-assert "^1.0.0"
+    minimalistic-crypto-utils "^1.0.0"
+
 emoji-regex@^7.0.1:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-7.0.3.tgz#933a04052860c85e83c122479c4748a8e4c72156"


### PR DESCRIPTION
It is:
- Fixing the issue reported here: https://github.com/teller-protocol/teller-protocol-v1/network/alerts

It includes:
- Upgraded elliptic@^6.5.3 to address the Dependabot alert
