### PR TITLE
[PROTOCOL-119] Adding Interest Validator

### DIFF
--- a/contracts/base/Lenders.sol
+++ b/contracts/base/Lenders.sol
@@ -64,32 +64,6 @@ contract Lenders is Base, LendersInterface {
     /** External Functions */
 
     /**
-        @notice It initializes this contract instance.
-        @param zTokenAddress zToken contract address.
-        @param lendingPoolAddress lending pool contract address.
-        @param interestConsensusAddress interest consensus contract address.
-        @param settingAddress settings contract address.
-        @param marketsAddress markets contract address.
-     */
-    function initialize(
-        address zTokenAddress,
-        address lendingPoolAddress,
-        address interestConsensusAddress,
-        address settingAddress,
-        address marketsAddress
-    ) external isNotInitialized() {
-        zTokenAddress.requireNotEmpty("ZTOKEN_MUST_BE_PROVIDED");
-        lendingPoolAddress.requireNotEmpty("LENDING_POOL_MUST_BE_PROVIDED");
-        interestConsensusAddress.requireNotEmpty("CONSENSUS_MUST_BE_PROVIDED");
-
-        _initialize(settingAddress, marketsAddress);
-
-        zToken = zTokenAddress;
-        lendingPool = lendingPoolAddress;
-        interestConsensus = InterestConsensusInterface(interestConsensusAddress);
-    }
-
-    /**
         @notice It sets the accrued interest for a lender based on the node responses.
         @param request interest request sent by the lender.
         @param responses all node responses to get a consensus value for the accrued interest.
@@ -153,6 +127,32 @@ contract Lenders is Base, LendersInterface {
         emit AccruedInterestWithdrawn(recipient, amount);
 
         return amount;
+    }
+
+    /**
+        @notice It initializes this contract instance.
+        @param zTokenAddress zToken contract address.
+        @param lendingPoolAddress lending pool contract address.
+        @param interestConsensusAddress interest consensus contract address.
+        @param settingAddress settings contract address.
+        @param marketsAddress markets contract address.
+     */
+    function initialize(
+        address zTokenAddress,
+        address lendingPoolAddress,
+        address interestConsensusAddress,
+        address settingAddress,
+        address marketsAddress
+    ) external isNotInitialized() {
+        zTokenAddress.requireNotEmpty("ZTOKEN_MUST_BE_PROVIDED");
+        lendingPoolAddress.requireNotEmpty("LENDING_POOL_MUST_BE_PROVIDED");
+        interestConsensusAddress.requireNotEmpty("CONSENSUS_MUST_BE_PROVIDED");
+
+        _initialize(settingAddress, marketsAddress);
+
+        zToken = zTokenAddress;
+        lendingPool = lendingPoolAddress;
+        interestConsensus = InterestConsensusInterface(interestConsensusAddress);
     }
 
     /** Internal Functions */

--- a/contracts/interfaces/InterestValidatorInterface.sol
+++ b/contracts/interfaces/InterestValidatorInterface.sol
@@ -1,0 +1,20 @@
+pragma solidity 0.5.17;
+
+
+/**
+    @notice This interface define the functio to validate the interest to withdraw by lenders.
+
+    @author develop@teller.finance
+ */
+interface InterestValidatorInterface {
+    /**
+        @notice It tests whether an interest for a given lender and market is valid or not.
+        @return true if the amount is valid. Otherwise it returns false.
+     */
+    function isInterestValid(
+        address borrowedAsset,
+        address collateralAsset,
+        address lender,
+        uint256 amount
+    ) external view returns (bool);
+}

--- a/contracts/interfaces/LendingPoolInterface.sol
+++ b/contracts/interfaces/LendingPoolInterface.sol
@@ -63,6 +63,18 @@ interface LendingPoolInterface {
     function lendingToken() external view returns (address);
 
     /**
+        @notice Gets the current interest validator. By default it is 0x0.
+        @return the interest validator contract address or empty address (0x0). 
+     */
+    function interestValidator() external view returns (address);
+
+    /**
+        @notice Update the current interest validator address.
+        @param newInterestValidator the new interest validator address.
+     */
+    function setInterestValidator(address newInterestValidator) external;
+
+    /**
         @notice This event is emitted when an user deposits tokens into the pool.
         @param sender address.
         @param amount of tokens.
@@ -96,4 +108,16 @@ interface LendingPoolInterface {
         @param amount of tokens.
      */
     event PaymentLiquidated(address indexed liquidator, uint256 amount);
+
+    /**
+        @notice This event is emitted when the interest validator is updated.
+        @param sender account that sends the transaction.
+        @param oldInterestValidator the old validator address.
+        @param newInterestValidator the new validator address.
+     */
+    event InterestValidatorUpdated(
+        address indexed sender,
+        address indexed oldInterestValidator,
+        address indexed newInterestValidator
+    );
 }

--- a/contracts/mock/base/BaseMock.sol
+++ b/contracts/mock/base/BaseMock.sol
@@ -18,7 +18,9 @@ contract BaseMock is Base {
         whenLendingPoolPaused(lendingPoolAddress)
     {}
 
-    function externalInitialize(address settingsAddress, address marketsAddress) external {
+    function externalInitialize(address settingsAddress, address marketsAddress)
+        external
+    {
         super._initialize(settingsAddress, marketsAddress);
     }
 

--- a/migrations/2_deploy.js
+++ b/migrations/2_deploy.js
@@ -101,12 +101,15 @@ module.exports = async function(deployer, network, accounts) {
   };
   const poolDeployer = new PoolDeployer(deployerApp, deployConfig, artifacts);
 
+  const InterestValidator = undefined; // The first version will be undefined (or 0x0).
+
   await poolDeployer.deployPool(
     { tokenName: 'DAI', collateralName: 'ETH' },
     {
       Loans: EtherCollateralLoans,
       TToken: ZDAI,
       MarketsState,
+      InterestValidator,
     },
     txConfig
   );
@@ -115,7 +118,8 @@ module.exports = async function(deployer, network, accounts) {
     {
       Loans: EtherCollateralLoans,
       TToken: ZUSDC,
-      MarketsState
+      MarketsState,
+      InterestValidator,
     },
     txConfig
   );
@@ -125,7 +129,8 @@ module.exports = async function(deployer, network, accounts) {
     {
       Loans: TokenCollateralLoans,
       TToken: ZDAI,
-      MarketsState
+      MarketsState,
+      InterestValidator,
     },
     txConfig
   );
@@ -134,7 +139,8 @@ module.exports = async function(deployer, network, accounts) {
     {
       Loans: TokenCollateralLoans,
       TToken: ZUSDC,
-      MarketsState
+      MarketsState,
+      InterestValidator,
     },
     txConfig
   );

--- a/migrations/utils/PoolDeployer.js
+++ b/migrations/utils/PoolDeployer.js
@@ -1,4 +1,5 @@
 const assert = require('assert');
+const { NULL_ADDRESS } = require('../../test/utils/consts');
 
 class PoolDeployer {
     constructor(deployer, deployConfig, artifacts) {
@@ -10,7 +11,7 @@ class PoolDeployer {
 
 PoolDeployer.prototype.deployPool = async function(
     { tokenName, collateralName, aggregatorName = `${tokenName.toUpperCase()}_${collateralName.toUpperCase()}`},
-    { Loans, TToken, MarketsState },
+    { Loans, TToken, MarketsState, InterestValidator },
     txConfig
 ) {
     assert(aggregatorName, 'Aggregator name is undefined.');
@@ -87,7 +88,9 @@ PoolDeployer.prototype.deployPool = async function(
         Settings.address,
         MarketsState.address,
     );
-    
+
+    const interestValidatorAddress = InterestValidator === undefined ? NULL_ADDRESS : InterestValidator.address;
+    console.log(`Lending pool is using interest validator ${interestValidatorAddress}.`)
     await lendingPoolInstance.initialize(
         TToken.address,
         tokenAddress,
@@ -96,6 +99,7 @@ PoolDeployer.prototype.deployPool = async function(
         cTokenAddress,
         settingsInstance.address,
         MarketsState.address,
+        interestValidatorAddress,
     );
   
     await zTokenInstance.addMinter(LendingPool.address, txConfig);
@@ -130,6 +134,10 @@ PoolDeployer.prototype.deployPool = async function(
         const result = await deployed.initialized();
         assert(result, `${initializable.contract_name} is NOT initialized.`);
     }
+
+    console.log('');
+    console.log('--- Pool deployment ends ---');
+    console.log('');
 }
 
 module.exports = PoolDeployer;

--- a/test/base/LendingPoolCreateLoanTest.js
+++ b/test/base/LendingPoolCreateLoanTest.js
@@ -1,6 +1,6 @@
 // JS Libraries
 const withData = require('leche').withData;
-const { t } = require('../utils/consts');
+const { t, NULL_ADDRESS } = require('../utils/consts');
 const ERC20InterfaceEncoder = require('../utils/encoders/ERC20InterfaceEncoder');
 const CompoundInterfaceEncoder = require('../utils/encoders/CompoundInterfaceEncoder');
 
@@ -46,6 +46,7 @@ contract('LendingPoolCreateLoanTest', function (accounts) {
             cTokenInstance.address,
             settingsInstance.address,
             marketsInstance.address,
+            NULL_ADDRESS,
         );
     });
 

--- a/test/base/LendingPoolDepositTest.js
+++ b/test/base/LendingPoolDepositTest.js
@@ -1,7 +1,7 @@
 // JS Libraries
 const withData = require('leche').withData;
 const {
-    t
+    t, NULL_ADDRESS
 } = require('../utils/consts');
 const {
     lendingPool
@@ -43,10 +43,12 @@ contract('LendingPoolDepositTest', function (accounts) {
         cTokenInstance = await Mock.new();
         marketsInstance = await Mock.new();
 
-        lendersInstance = await Lenders.new(
+        lendersInstance = await Lenders.new();
+        await lendersInstance.initialize(
             zTokenInstance.address,
             instance.address,
             interestConsensusInstance.address,
+            settingsInstance.address,
             marketsInstance.address,
         );
 
@@ -58,6 +60,7 @@ contract('LendingPoolDepositTest', function (accounts) {
             cTokenInstance.address,
             settingsInstance.address,
             marketsInstance.address,
+            NULL_ADDRESS,
         );
     });
 
@@ -144,6 +147,7 @@ contract('LendingPoolDepositTest', function (accounts) {
                 cTokenInstance.address,
                 settingsInstance.address,
                 marketsInstance.address,
+                NULL_ADDRESS,
             );
 
             const encodeTransferFrom = erc20InterfaceEncoder.encodeTransferFrom();

--- a/test/base/LendingPoolInitializeTest.js
+++ b/test/base/LendingPoolInitializeTest.js
@@ -18,17 +18,20 @@ contract('LendingPoolInitializeTest', function (accounts) {
     const getInstance = (refs, index, accountIndex) => index === -1 ? NULL_ADDRESS: index === 99 ? accounts[accountIndex] : refs[index];
 
     withData({
-        _1_basic: [2, 3, 4, 5, 6, 7, 8, undefined, false],
-        _2_notZdai: [-1, 3, 4, 5, 6, 7, 8, 'ZTOKEN_ADDRESS_IS_REQUIRED', true],
-        _3_notDai: [2, -1, 4, 5, 6, 7, 8, 'TOKEN_ADDRESS_IS_REQUIRED', true],
-        _4_notLenderInfo: [2, 3, -1, 5, 6, 7, 8, 'LENDERS_ADDRESS_IS_REQUIRED', true],
-        _5_notLoanInfo: [2, 3, 4, -1, 6, 7, 8, 'LOANS_ADDRESS_IS_REQUIRED', true],
-        _6_notCToken: [2, 3, 4, 5, -1, 7, 8, undefined, false],
-        _7_notZdai_notLoanInfo: [-1, 3, 4, -1, 6, 7, 8, 'ZTOKEN_ADDRESS_IS_REQUIRED', true],
-        _8_notDai_notLenderInfo: [2, -1, -1, 5, 6, 7, 8, 'TOKEN_ADDRESS_IS_REQUIRED', true],
-        _9_notSettings: [2, 3, 4, 5, 6, -1, 8, 'SETTINGS_MUST_BE_PROVIDED', true],
-        _10_notMarkets: [2, 3, 4, 5, 6, 8, -1, 'MARKETS_MUST_BE_PROVIDED', true],
-        _11_notMarkets_not_contract: [2, 3, 4, 5, 6, 8, 99, 'MARKETS_MUST_BE_A_CONTRACT', true],
+        _1_basic: [2, 3, 4, 5, 6, 7, 8, 9, undefined, false],
+        _2_notZdai: [-1, 3, 4, 5, 6, 7, 8, 9, 'ZTOKEN_ADDRESS_IS_REQUIRED', true],
+        _3_notDai: [2, -1, 4, 5, 6, 7, 8, 9, 'TOKEN_ADDRESS_IS_REQUIRED', true],
+        _4_notLenderInfo: [2, 3, -1, 5, 6, 7, 8, 9, 'LENDERS_ADDRESS_IS_REQUIRED', true],
+        _5_notLoanInfo: [2, 3, 4, -1, 6, 7, 8, 9, 'LOANS_ADDRESS_IS_REQUIRED', true],
+        _6_notCToken: [2, 3, 4, 5, -1, 7, 8, 9, undefined, false],
+        _7_notZdai_notLoanInfo: [-1, 3, 4, -1, 6, 7, 8, 9, 'ZTOKEN_ADDRESS_IS_REQUIRED', true],
+        _8_notDai_notLenderInfo: [2, -1, -1, 5, 6, 7, 8, 9, 'TOKEN_ADDRESS_IS_REQUIRED', true],
+        _9_notSettings: [2, 3, 4, 5, 6, -1, 8, 9, 'SETTINGS_MUST_BE_PROVIDED', true],
+        _10_notMarkets: [2, 3, 4, 5, 6, 7, -1, 9, 'MARKETS_MUST_BE_PROVIDED', true],
+        _11_notMarkets_not_contract: [2, 3, 4, 5, 6, 7, 99, 9, 'MARKETS_MUST_BE_A_CONTRACT', true],
+        _12_notInterestValidator: [2, 3, 4, 5, 6, 7, 8, -1, undefined, false],
+        _13_notInterestValidator_not_contract: [2, 3, 4, 5, 6, 7, 8, 99, 'VAL_MUST_BE_EMPTY_OR_CONTRACT', true],
+        _14_notInterestValidator_not_contract_2: [2, 3, 4, 5, 6, 7, 8, 9, undefined, false],
     }, function(
         zdaiIndex,
         daiIndex,
@@ -37,6 +40,7 @@ contract('LendingPoolInitializeTest', function (accounts) {
         cTokenIndex,
         settingsIndex,
         marketsIndex,
+        interestValidatorIndex,
         expectedErrorMessage,
         mustFail
     ) {    
@@ -50,6 +54,7 @@ contract('LendingPoolInitializeTest', function (accounts) {
             const cTokenAddress = getInstance(mocks, cTokenIndex, 6);
             const settingsAddress = getInstance(mocks, settingsIndex, 7);
             const marketsAddress = getInstance(mocks, marketsIndex, 7);
+            const interestValidatorAddress = getInstance(mocks, interestValidatorIndex, 8);
 
             try {
                 // Invocation
@@ -61,6 +66,7 @@ contract('LendingPoolInitializeTest', function (accounts) {
                     cTokenAddress,
                     settingsAddress,
                     marketsAddress,
+                    interestValidatorAddress,
                 );;
                 
                 // Assertions

--- a/test/base/LendingPoolLiquidationPaymentTest.js
+++ b/test/base/LendingPoolLiquidationPaymentTest.js
@@ -74,6 +74,7 @@ contract('LendingPoolLiquidationPaymentTest', function (accounts) {
                 cTokenAddress,
                 settingsInstance.address,
                 marketsInstance.address,
+                NULL_ADDRESS,
             );
             const encodeTransferFrom = erc20InterfaceEncoder.encodeTransferFrom();
             await daiInstance.givenMethodReturnBool(encodeTransferFrom, transferFrom);

--- a/test/base/LendingPoolRepayTest.js
+++ b/test/base/LendingPoolRepayTest.js
@@ -75,6 +75,7 @@ contract('LendingPoolRepayTest', function (accounts) {
                 cTokenAddress,
                 settingsInstance.address,
                 marketsInstance.address,
+                NULL_ADDRESS,
             );
             const encodeTransferFrom = erc20InterfaceEncoder.encodeTransferFrom();
             await daiInstance.givenMethodReturnBool(encodeTransferFrom, transferFrom);

--- a/test/base/LendingPoolSetInterestValidatorTest.js
+++ b/test/base/LendingPoolSetInterestValidatorTest.js
@@ -1,0 +1,102 @@
+// JS Libraries
+const withData = require('leche').withData;
+const { t, NULL_ADDRESS } = require('../utils/consts');
+const { lendingPool } = require('../utils/events');
+const SettingsInterfaceEncoder = require('../utils/encoders/SettingsInterfaceEncoder');
+
+// Mock contracts
+const Mock = artifacts.require("./mock/util/Mock.sol");
+
+// Smart contracts
+const LendingPool = artifacts.require("./base/LendingPool.sol");
+
+contract('LendingPoolSetInterestValidatorTest', function (accounts) {
+    const settingsInterfaceEncoder = new SettingsInterfaceEncoder(web3);
+    let instance;
+    let settingsInstance;
+    let interestValidatorInstance;
+
+    beforeEach('Setup for each test', async () => {
+        const loansInstance = await Mock.new();
+        settingsInstance = await Mock.new();
+        const zTokenInstance = await Mock.new();
+        const lendingTokenInstance = await Mock.new();
+        const cTokenInstance = await Mock.new()
+        const lendersInstance = await Mock.new();
+        const marketsInstance = await Mock.new();
+        interestValidatorInstance = await Mock.new();
+        
+        instance = await LendingPool.new();
+        await instance.initialize(
+            zTokenInstance.address,
+            lendingTokenInstance.address,
+            lendersInstance.address,
+            loansInstance.address,
+            cTokenInstance.address,
+            settingsInstance.address,
+            marketsInstance.address,
+            interestValidatorInstance.address,
+        );
+    });
+
+    const getNewInterestValidator = async (newPriceOracleIndex, Mock) => {
+        if (newPriceOracleIndex === -1) {
+            return NULL_ADDRESS;
+        }
+        if (newPriceOracleIndex === 0) {
+            return interestValidatorInstance.address;
+        }
+        if (newPriceOracleIndex === 99) {
+            return (await Mock.new()).address;
+        }
+        return accounts[newPriceOracleIndex];
+    };
+
+    withData({
+        _1_basic: [1, true, 99, undefined, false],
+        _2_sender_not_allowed: [1, false, 99, 'ADDRESS_ISNT_ALLOWED', true],
+        _3_same_address: [1, true, 0, 'NEW_VALIDATOR_MUST_BE_PROVIDED', true],
+        _4_not_contract: [1, true, 2, 'VALIDATOR_MUST_CONTRACT_NT_EMPTY', true],
+    }, function(senderIndex, hasPauserRole, newInterestValidatorIndex, expectedErrorMessage, mustFail) {
+        it(t('user', 'setInterestValidator', 'Should be able (or not) to set a new interest validator instance.', mustFail), async function() {
+            // Setup
+            const sender = senderIndex === -1 ? NULL_ADDRESS : accounts[senderIndex];
+            /*
+                If index = -1 => empty address (0x0)
+                If index = 99 => a new contract address
+                If index = 0 => current validator address.
+                Otherwise accounts[index]
+            */
+            const newInterestValidator = await getNewInterestValidator(newInterestValidatorIndex, Mock);
+
+            await settingsInstance.givenMethodReturnBool(
+                settingsInterfaceEncoder.encodeHasPauserRole(),
+                hasPauserRole
+            );
+
+            try {
+                // Invocation
+                const result = await instance.setInterestValidator(
+                    newInterestValidator,
+                    {
+                        from: sender,
+                    }
+                );
+
+                // Assertions
+                assert(!mustFail, 'It should have failed because data is invalid.');
+                assert(result);
+
+                lendingPool
+                    .interestValidatorUpdated(result)
+                    .emitted(sender, interestValidatorInstance.address, newInterestValidator);
+                
+            } catch (error) {
+                // Assertions
+                assert(mustFail);
+                assert(error);
+                assert.equal(error.reason, expectedErrorMessage);
+            }
+        })
+    })
+})

--- a/test/base/LendingPoolWithdrawTest.js
+++ b/test/base/LendingPoolWithdrawTest.js
@@ -1,6 +1,6 @@
 // JS Libraries
 const withData = require('leche').withData;
-const { t } = require('../utils/consts');
+const { t, NULL_ADDRESS } = require('../utils/consts');
 const { lendingPool } = require('../utils/events');
 const { initContracts } = require('../utils/contracts');
 const BurnableInterfaceEncoder = require('../utils/encoders/BurnableInterfaceEncoder');
@@ -54,7 +54,18 @@ contract('LendingPoolWithdrawTest', function (accounts) {
             // Setup
             const zTokenInstance = await Mock.new();
             const lendingTokenInstance = await Mock.new();
-            await initContracts(settingsInstance, cTokenInstance, instance, zTokenInstance, consensusInstance, lendingTokenInstance, loansInstance, marketsInstance, Lenders);
+            await initContracts(
+                settingsInstance,
+                cTokenInstance,
+                instance,
+                zTokenInstance,
+                consensusInstance,
+                lendingTokenInstance,
+                loansInstance,
+                marketsInstance,
+                NULL_ADDRESS,
+                Lenders,
+            );
             const encodeTransfer = burnableInterfaceEncoder.encodeTransfer();
             await lendingTokenInstance.givenMethodReturnBool(encodeTransfer, transfer);
 
@@ -94,7 +105,18 @@ contract('LendingPoolWithdrawTest', function (accounts) {
             const zTokenInstance = await ZDai.new();
             const lendingTokenInstance = await Token.new();
             await zTokenInstance.addMinter(instance.address);
-            await initContracts(settingsInstance, cTokenInstance, instance, zTokenInstance, consensusInstance, lendingTokenInstance, loansInstance, marketsInstance, Lenders);
+            await initContracts(
+                settingsInstance,
+                cTokenInstance,
+                instance,
+                zTokenInstance,
+                consensusInstance,
+                lendingTokenInstance,
+                loansInstance,
+                marketsInstance,
+                NULL_ADDRESS,
+                Lenders,
+            );
             await lendingTokenInstance.approve(instance.address, depositAmount, { from: depositSender });
             await instance.deposit(depositAmount, { from: depositSender });
             

--- a/test/utils/contracts.js
+++ b/test/utils/contracts.js
@@ -8,7 +8,7 @@ module.exports = {
             lenderData.lastAccruedInterest
         );
     },
-    initContracts: async (settings, cToken, lendingPool, zToken, consensus, lendingToken, loans, markets, Lenders) => {
+    initContracts: async (settings, cToken, lendingPool, zToken, consensus, lendingToken, loans, markets, interestValidatorAddress, Lenders) => {
         const lenders = await Lenders.new();
         await lenders.initialize(
             zToken.address,
@@ -25,6 +25,7 @@ module.exports = {
             cToken.address,
             settings.address,
             markets.address,
+            interestValidatorAddress,
         );
         return lenders;
     },

--- a/test/utils/encoders/InterestValidatorInterfaceEncoder.js
+++ b/test/utils/encoders/InterestValidatorInterfaceEncoder.js
@@ -1,0 +1,14 @@
+const { encode } = require('../consts');
+
+class InterestValidatorInterfaceEncoder {
+    constructor(web3) {
+        this.web3 = web3;
+        assert(web3, 'Web3 instance is required.');
+    }
+}
+
+InterestValidatorInterfaceEncoder.prototype.encodeIsInterestValid = function() {
+    return encode(this.web3, 'isInterestValid(address,address,address,uint256)');
+}
+
+module.exports = InterestValidatorInterfaceEncoder;

--- a/test/utils/events.js
+++ b/test/utils/events.js
@@ -115,6 +115,18 @@ module.exports = {
                 notEmitted: (assertFunction = () => {} ) => notEmitted(tx, name, assertFunction)
             };
         },
+        interestValidatorUpdated: tx => {
+            const name = 'InterestValidatorUpdated';
+            return {
+                name: name,
+                emitted: (sender, oldInterestValidator, newInterestValidator) => emitted(tx, name, ev => {
+                    assert.equal(ev.sender.toString(), sender.toString());
+                    assert.equal(ev.oldInterestValidator.toString(), oldInterestValidator.toString());
+                    assert.equal(ev.newInterestValidator.toString(), newInterestValidator.toString());
+                }),
+                notEmitted: (assertFunction = () => {} ) => notEmitted(tx, name, assertFunction)
+            };
+        },
     },
     loans: {
         loanTermsSet: tx => {


### PR DESCRIPTION
It includes:

- A new InterestValidator interface to be used in the LendingPool.withdrawInterest function. By default, it will be empty. So we will not be validating the amount to withdraw. But it allows us to implement a new version in the future.
- New unit tests

![image](https://user-images.githubusercontent.com/5948309/89955379-4776b600-dc09-11ea-8eff-840b2dcf0354.png)
