### PR TITLE
[PROTOCOL-267] Limit Escrow interaction with unsecured loans.

### DIFF
--- a/contracts/base/EscrowFactory.sol
+++ b/contracts/base/EscrowFactory.sol
@@ -40,12 +40,9 @@ contract EscrowFactory is EscrowFactoryInterface, TInitializable, BaseUpgradeabl
     /* State Variables */
 
     /**
-        @notice It defines whether a DApp exists or not.
-        Example:
-            address(0x123...456) => true
-            address(0x456...789) => false
+        @notice It holds the Dapp's configuration.
      */
-    mapping(address => bool) public dapps;
+    mapping(address => TellerCommon.Dapp) public dapps;
 
     /**
         @notice It contains all the dapps added in this factory.
@@ -87,26 +84,31 @@ contract EscrowFactory is EscrowFactoryInterface, TInitializable, BaseUpgradeabl
     }
 
     /**
-        @notice It tests whether an address is a dapp or not.
-        @param dapp address to test.
-        @return true if the address is a dapp. Otherwise it returns false.
-     */
-    function isDapp(address dapp) external view returns (bool) {
-        return _isDapp(dapp);
-    }
-
-    /**
         @notice It adds a new dapp to the factory.
         @param dapp address to add in this factory.
+        @param unsecured boolean to describe in the dapp is allowed to be used with unsecured loans.
      */
-    function addDapp(address dapp) external onlyPauser() isInitialized() {
+    function addDapp(address dapp, bool unsecured) external onlyPauser() isInitialized() {
         require(dapp.isContract(), "DAPP_ISNT_A_CONTRACT");
         require(!_isDapp(dapp), "DAPP_ALREADY_EXIST");
 
-        dapps[dapp] = true;
+        dapps[dapp] = TellerCommon.Dapp({ exists: true, unsecured: unsecured });
         dappsList.add(dapp);
 
-        emit NewDAppAdded(msg.sender, dapp);
+        emit NewDappAdded(msg.sender, dapp, unsecured);
+    }
+
+    /**
+        @notice It updates a dapp configuration.
+        @param dapp address to add in this factory.
+        @param unsecured boolean that describes if the dapp can be used by with an unsecured loan.
+     */
+    function updateDapp(address dapp, bool unsecured) external onlyPauser() isInitialized() {
+        require(_isDapp(dapp), "DAPP_NOT_EXIST");
+
+        dapps[dapp].unsecured = unsecured;
+
+        emit DappUpdated(msg.sender, dapp, unsecured);
     }
 
     /**
@@ -117,10 +119,10 @@ contract EscrowFactory is EscrowFactoryInterface, TInitializable, BaseUpgradeabl
         require(dapp.isContract(), "DAPP_ISNT_A_CONTRACT");
         require(_isDapp(dapp), "DAPP_NOT_EXIST");
 
-        dapps[dapp] = false;
+        dapps[dapp].exists = false;
         dappsList.remove(dapp);
 
-        emit DAppRemoved(msg.sender, dapp);
+        emit DappRemoved(msg.sender, dapp);
     }
 
     /**
@@ -150,6 +152,6 @@ contract EscrowFactory is EscrowFactoryInterface, TInitializable, BaseUpgradeabl
         @return true if the address is a dapp. Otherwise it returns false.
      */
     function _isDapp(address dapp) internal view returns (bool) {
-        return dapps[dapp];
+        return dapps[dapp].exists;
     }
 }

--- a/contracts/base/LoansBase.sol
+++ b/contracts/base/LoansBase.sol
@@ -174,6 +174,10 @@ contract LoansBase is LoansInterface, Base {
         return lendingPool.cToken();
     }
 
+    function isLoanSecured(uint256 loanID) external view returns (bool) {
+        return loans[loanID].loanTerms.collateralRatio >= settings().getPlatformSettingValue(settings().consts().COLLATERAL_BUFFER_SETTING());
+    }
+
     /**
      * @notice Withdraw collateral from a loan, unless this isn't allowed
      * @param amount The amount of collateral token or ether the caller is hoping to withdraw.

--- a/contracts/base/LoansBase.sol
+++ b/contracts/base/LoansBase.sol
@@ -174,6 +174,10 @@ contract LoansBase is LoansInterface, Base {
         return lendingPool.cToken();
     }
 
+    /**
+        @notice Checks wheather the loan's collateral ratio is considered to be secured based on the settings collateral buffer value.
+        @return bool value of it being secured or not.
+    */
     function isLoanSecured(uint256 loanID) external view returns (bool) {
         return loans[loanID].loanTerms.collateralRatio >= settings().getPlatformSettingValue(settings().consts().COLLATERAL_BUFFER_SETTING());
     }

--- a/contracts/interfaces/EscrowFactoryInterface.sol
+++ b/contracts/interfaces/EscrowFactoryInterface.sol
@@ -1,4 +1,7 @@
 pragma solidity 0.5.17;
+pragma experimental ABIEncoderV2;
+
+import "../util/TellerCommon.sol";
 
 /**
     @notice This interface defines the functions to manage the Escrow contracts associated to borrowers and loans.
@@ -7,11 +10,11 @@ pragma solidity 0.5.17;
  */
 interface EscrowFactoryInterface {
     /**
-        @notice It tests whether a dapp address exists in the factory or not.
-        @param dapp dapp address to test.
-        @return true if the dapp address already exists. Otherwise it returns false.
+        @notice It gets a dapp configuration based its contract address.
+        @param dapp dapp address.
+        @return TellerCommon.Dapp dapp configuration.
      */
-    function isDapp(address dapp) external view returns (bool);
+    function dapps(address dapp) external view returns (TellerCommon.Dapp memory);
 
     /**
         @notice It creates an Escrow contract for a given loan id.
@@ -24,8 +27,16 @@ interface EscrowFactoryInterface {
     /**
         @notice It adds a new dapp to the factory.
         @param dapp address to add in this factory.
+        @param unsecured boolean to describe in the dapp is allowed to be used with unsecured loans.
      */
-    function addDapp(address dapp) external;
+    function addDapp(address dapp, bool unsecured) external;
+
+    /**
+        @notice It updates a dapp configuration.
+        @param dapp address to add in this factory.
+        @param unsecured boolean that describes if the dapp can be used by with an unsecured loan.
+     */
+    function updateDapp(address dapp, bool unsecured) external;
 
     /**
         @notice It removes a current dapp from the factory.
@@ -62,14 +73,23 @@ interface EscrowFactoryInterface {
     /**
         @notice This event is emitted when a new dapp is added to the factory.
         @param sender address.
-        @param dapp address addded to the factory.
+        @param dapp address added to the factory.
+        @param unsecured boolean that describes if the dapp can be used by with an unsecured loan.
      */
-    event NewDAppAdded(address indexed sender, address indexed dapp);
+    event NewDappAdded(address indexed sender, address indexed dapp, bool unsecured);
+
+    /**
+        @notice This event is emitted when a dapp is updated.
+        @param sender address.
+        @param dapp address of dapp contract.
+        @param unsecured boolean that describes if the dapp can be used by with an unsecured loan.
+     */
+    event DappUpdated(address indexed sender, address indexed dapp, bool unsecured);
 
     /**
         @notice This event is emitted when a current dapp is removed from the factory.
         @param sender address.
         @param dapp address removed from the factory.
      */
-    event DAppRemoved(address indexed sender, address indexed dapp);
+    event DappRemoved(address indexed sender, address indexed dapp);
 }

--- a/contracts/interfaces/LoansInterface.sol
+++ b/contracts/interfaces/LoansInterface.sol
@@ -264,4 +264,10 @@ interface LoansInterface {
         @return Address of the cToken
      */
     function cToken() external view returns (address);
+
+    /**
+        @notice Returns whether or not the loan is considered secured.
+        @return bool Whether or not the loan is considered secured.
+     */
+    function isLoanSecured(uint256 loanID) external view returns (bool);
 }

--- a/contracts/mock/base/EscrowMock.sol
+++ b/contracts/mock/base/EscrowMock.sol
@@ -34,11 +34,8 @@ contract EscrowMock is Escrow, BaseEscrowDappMock {
         _setSettings(settingsAddress);
     }
 
-    function mockBorrowerAndStatus(address borrower, TellerCommon.LoanStatus loanStatus)
-        public
-    {
+    function mockBorrower(address borrower) public {
         _borrower = borrower;
-        _loanStatus = loanStatus;
     }
 
     function isOwner() public view returns (bool) {

--- a/contracts/util/TellerCommon.sol
+++ b/contracts/util/TellerCommon.sol
@@ -118,6 +118,15 @@ library TellerCommon {
         @notice This struct defines the dapp address and data to execute in the callDapp function.
         @dev It is executed using a delegatecall in the Escrow contract.
      */
+    struct Dapp {
+        bool exists;
+        bool unsecured;
+    }
+
+    /**
+        @notice This struct defines the dapp address and data to execute in the callDapp function.
+        @dev It is executed using a delegatecall in the Escrow contract.
+     */
     struct DappData {
         address location;
         bytes data;

--- a/test/base/EscrowFactoryRemoveDAppTest.js
+++ b/test/base/EscrowFactoryRemoveDAppTest.js
@@ -11,7 +11,7 @@ const Mock = artifacts.require("./mock/util/Mock.sol");
 const Settings = artifacts.require("./base/Settings.sol");
 const EscrowFactory = artifacts.require("./base/EscrowFactory.sol");
 
-contract('EscrowFactoryRemoveDAppTest', function (accounts) {
+contract('EscrowFactoryRemoveDappTest', function (accounts) {
   const owner = accounts[0];
   let instance;
   let mocks;
@@ -65,11 +65,10 @@ contract('EscrowFactoryRemoveDAppTest', function (accounts) {
         const dappAddressFound = finalDapps.find(aDappAddress => aDappAddress === dappAddress);
         assert(dappAddressFound === undefined);
 
-        const isDapp = await instance.isDapp(dappAddress);
-        assert(!isDapp);
+        const dapp = await instance.dapps.call(dappAddress);
+        assert(!dapp.exists);
       } catch (error) {
-        assert(mustFail);
-        assert(error);
+        assert(mustFail, error.message);
         assert.equal(error.reason, expectedErrorMessage);
       }
     });

--- a/test/base/EscrowFactoryUpdateDAppTest.js
+++ b/test/base/EscrowFactoryUpdateDAppTest.js
@@ -1,0 +1,64 @@
+// JS Libraries
+const withData = require('leche').withData;
+const { t, createMocks, NULL_ADDRESS } = require('../utils/consts');
+const { escrowFactory } = require('../utils/events');
+const assert = require('assert');
+
+// Mock contracts
+const Mock = artifacts.require("./mock/util/Mock.sol");
+
+// Smart contracts
+const Settings = artifacts.require("./base/Settings.sol");
+const EscrowFactory = artifacts.require("./base/EscrowFactory.sol");
+
+contract('EscrowFactoryUpdateDappTest', function (accounts) {
+  const owner = accounts[0];
+  let instance;
+  let mocks;
+
+  beforeEach(async () => {
+    instance = await EscrowFactory.new();
+    const settings = await Settings.new();
+    await settings.initialize(owner);
+    await instance.initialize(settings.address, { from: owner });
+
+    mocks = await createMocks(Mock, 10);
+  })
+
+  withData({
+    _1_to_unsecured: [owner, true, true, false, null],
+    _2_to_secured: [owner, true, false, false, null],
+    _3_not_exist: [owner, false, true, true, 'DAPP_NOT_EXIST'],
+    _4_not_pauser: [accounts[5], true, true, true, 'NOT_PAUSER'],
+  }, function(
+    caller,
+    exists,
+    toUnsecured,
+    mustFail,
+    expectedErrorMessage
+  ) {
+    it(t('escrowFactory', 'updateDapp', 'Should be able (or not) to update an existing dapp.', mustFail), async function() {
+      // Setup
+      const dapp = await Mock.new();
+      if (exists) {
+        await instance.addDapp(dapp.address, !toUnsecured, { from: owner });
+      }
+
+      try {
+        // Invocation
+        const result = await instance.updateDapp(dapp.address, toUnsecured, { from: caller });
+
+        // Assertions
+        assert(!mustFail, 'It should have failed because data is invalid.');
+        assert(result);
+
+        escrowFactory
+          .dappUpdated(result)
+          .emitted(caller, dapp.address, toUnsecured);
+      } catch (error) {
+        assert(mustFail, error.message);
+        assert.equal(error.reason, expectedErrorMessage);
+      }
+    });
+  });
+});

--- a/test/base/LoansBaseIsLoanSecuredTest.js
+++ b/test/base/LoansBaseIsLoanSecuredTest.js
@@ -1,0 +1,51 @@
+// JS Libraries
+const withData = require("leche").withData;
+const { t, NULL_ADDRESS } = require("../utils/consts");
+const settingsNames = require("../utils/platformSettingsNames");
+const { createLoanTerms } = require("../utils/structs");
+const { createTestSettingsInstance } = require("../utils/settings-helper");
+
+// Mock contracts
+const Mock = artifacts.require("./mock/util/Mock.sol");
+
+// Smart contracts
+const Loans = artifacts.require("./mock/base/LoansBaseMock.sol");
+const Settings = artifacts.require("./base/Settings.sol");
+
+contract("LoansBaseIsLoanSecuredTest", function(accounts) {
+  let instance;
+
+  const settingsCollateralBuffer = 1000;
+
+  beforeEach("Setup for each test", async () => {
+    const settings = await createTestSettingsInstance(Settings, { from: accounts[0], Mock }, {
+      [settingsNames.CollateralBuffer]: settingsCollateralBuffer
+    });
+
+    instance = await Loans.new();
+    await instance.externalInitialize(settings.address);
+  });
+
+  withData({
+    _1_collateral_ratio_same_as_settings_buffer: [ settingsCollateralBuffer, true ],
+    _2_collateral_ratio_gt_settings_buffer: [ settingsCollateralBuffer + settingsCollateralBuffer, true ],
+    _3_collateral_ratio_lt_settings_buffer: [ settingsCollateralBuffer - 100, false ],
+    _3_collateral_ratio_0: [ 0, false ]
+  }, function(
+    collateralRatio,
+    expectedResult
+  ) {
+    it(t("user", "isLoanSecured", "Should able to test whether a loan is considered to be secured.", false), async function() {
+      // Setup
+      const loanTerms = createLoanTerms(NULL_ADDRESS, NULL_ADDRESS, 0, collateralRatio, 0, 0);
+      const loanID = 1234;
+      await instance.setLoan(loanID, loanTerms, 0, 0, 0, 0, 0, 0, 0, 1, false);
+
+      // Invocation
+      const isSecured = await instance.isLoanSecured.call(loanID);
+
+      // Assertions
+      assert.equal(isSecured, expectedResult, "Result does not match expected value");
+    });
+  });
+});

--- a/test/utils/encoders/EscrowFactoryEncoder.js
+++ b/test/utils/encoders/EscrowFactoryEncoder.js
@@ -11,6 +11,10 @@ EscrowFactoryEncoder.prototype.encodeIsDapp = function() {
     return encode(this.web3, 'isDapp(address)');
 }
 
+EscrowFactoryEncoder.prototype.encodeDapps = function() {
+    return encode(this.web3, 'dapps(address)');
+}
+
 EscrowFactoryEncoder.prototype.encodeCreateEscrow = function() {
     return encode(this.web3, 'createEscrow(address,uint256)');
 }

--- a/test/utils/encoders/LoansBaseInterfaceEncoder.js
+++ b/test/utils/encoders/LoansBaseInterfaceEncoder.js
@@ -30,4 +30,8 @@ LoansBaseInterfaceEncoder.prototype.encodeRepay = function() {
     return encode(this.web3, 'repay(uint256,uint256)');
 }
 
+LoansBaseInterfaceEncoder.prototype.encodeIsLoanSecured = function() {
+    return encode(this.web3, 'isLoanSecured(uint256)');
+}
+
 module.exports = LoansBaseInterfaceEncoder;

--- a/test/utils/escrow.js
+++ b/test/utils/escrow.js
@@ -1,0 +1,16 @@
+const { NULL_ADDRESS, ACTIVE } = require("./consts");
+
+exports.encodeDappConfigParameter = (web3, {
+  exists = true,
+  unsecured = true
+}) => {
+  return web3.eth.abi.encodeParameter({
+    Dapp: {
+      exists: "bool",
+      unsecrude: "bool"
+    }
+  }, {
+    exists,
+    unsecured
+  });
+};

--- a/test/utils/events.js
+++ b/test/utils/events.js
@@ -732,19 +732,32 @@ module.exports = {
                 notEmitted: (assertFunction = () => {} ) => notEmitted(tx, name, assertFunction)
             };
         },
-        newDAppAdded: tx => {
-            const name = 'NewDAppAdded';
+        newDappAdded: tx => {
+            const name = 'NewDappAdded';
             return {
                 name: name,
-                emitted: (sender, dapp) => emitted(tx, name, ev => {
+                emitted: (sender, dapp, unsecured) => emitted(tx, name, ev => {
                     assert.equal(ev.sender.toString(), sender.toString());
                     assert.equal(ev.dapp.toString(), dapp.toString());
+                    assert.equal(ev.unsecured, unsecured);
+                }),
+                notEmitted: (assertFunction = () => {} ) => notEmitted(tx, name, assertFunction)
+            };
+        },
+        dappUpdated: tx => {
+            const name = 'DappUpdated';
+            return {
+                name: name,
+                emitted: (sender, dapp, unsecured) => emitted(tx, name, ev => {
+                    assert.equal(ev.sender.toString(), sender.toString());
+                    assert.equal(ev.dapp.toString(), dapp.toString());
+                    assert.equal(ev.unsecured, unsecured);
                 }),
                 notEmitted: (assertFunction = () => {} ) => notEmitted(tx, name, assertFunction)
             };
         },
         dappRemoved: tx => {
-            const name = 'DAppRemoved';
+            const name = 'DappRemoved';
             return {
                 name: name,
                 emitted: (sender, dapp) => emitted(tx, name, ev => {


### PR DESCRIPTION
It:
* Restricts interactions for Escrows that are for an unsecured loan to Dapps that are marked as `unsecured`