### PR TITLE
[PROTOCOL-330] Add Signer Nonce in LoanTermsSubmitted event

### DIFF
--- a/contracts/base/LoanTermsConsensus.sol
+++ b/contracts/base/LoanTermsConsensus.sol
@@ -141,6 +141,7 @@ contract LoanTermsConsensus is LoanTermsConsensusInterface, Consensus {
             response.signer,
             request.borrower,
             request.requestNonce,
+            response.signature.signerNonce,
             response.interestRate,
             response.collateralRatio,
             response.maxLoanAmount

--- a/contracts/interfaces/LoanTermsConsensusInterface.sol
+++ b/contracts/interfaces/LoanTermsConsensusInterface.sol
@@ -22,6 +22,7 @@ interface LoanTermsConsensusInterface {
         address indexed signer,
         address indexed borrower,
         uint256 indexed requestNonce,
+        uint256 signerNonce,
         uint256 interestRate,
         uint256 collateralRatio,
         uint256 maxLoanAmount

--- a/test/base/LoanTermsConsensusProcessRequestTest.js
+++ b/test/base/LoanTermsConsensusProcessRequestTest.js
@@ -192,6 +192,7 @@ contract('LoanTermsConsensusProcessRequestTest', function (accounts) {
                             response.signer,
                             borrower,
                             requestNonce,
+                            response.signature.signerNonce,
                             response.interestRate,
                             response.collateralRatio,
                             response.maxLoanAmount

--- a/test/base/LoanTermsConsensusProcessResponseTest.js
+++ b/test/base/LoanTermsConsensusProcessResponseTest.js
@@ -161,7 +161,7 @@ contract('LoanTermsConsensusProcessResponseTest', function (accounts) {
 
                 loanTermsConsensus
                     .termsSubmitted(result)
-                    .emitted(nodeAddress, borrower, requestNonce, interestRate, collateralRatio, maxLoanAmount.toFixed());
+                    .emitted(nodeAddress, borrower, requestNonce, loanResponse.signature.signerNonce, interestRate, collateralRatio, maxLoanAmount.toFixed());
 
                 let submissions = await instance.termSubmissions.call(borrower, requestNonce)
 

--- a/test/utils/events.js
+++ b/test/utils/events.js
@@ -304,11 +304,12 @@ module.exports = {
             const name = 'TermsSubmitted';
             return {
                 name: name,
-                emitted: (signer, borrower, requestNonce, interestRate, collateralRatio, maxLoanAmount) => truffleAssert.eventEmitted(tx, name, ev => {
+                emitted: (signer, borrower, requestNonce, signerNonce, interestRate, collateralRatio, maxLoanAmount) => truffleAssert.eventEmitted(tx, name, ev => {
                     return (
                         ev.signer === signer && 
                         ev.borrower === borrower &&
                         ev.requestNonce.toString() === requestNonce.toString() &&
+                        ev.signerNonce.toString() === signerNonce.toString() &&
                         ev.interestRate.toString() === interestRate.toString() &&
                         ev.collateralRatio.toString() === collateralRatio.toString() &&
                         ev.maxLoanAmount.toString() === maxLoanAmount.toString()


### PR DESCRIPTION
It includes:

The signer nonce value in the LoanTermsSubmitted event.