### PR TITLE
Removing AddressArrayLib return parameters

### DIFF
--- a/contracts/util/AddressArrayLib.sol
+++ b/contracts/util/AddressArrayLib.sol
@@ -62,7 +62,7 @@ library AddressArrayLib {
     */
     function remove(address[] storage self, address item) internal {
         (bool found, uint256 indexAt) = getIndex(self, item);
-        if (!found) return self;
+        if (!found) return;
 
         removeAt(self, indexAt);
     }

--- a/contracts/util/AddressArrayLib.sol
+++ b/contracts/util/AddressArrayLib.sol
@@ -11,9 +11,7 @@ library AddressArrayLib {
       @param self current array.
       @param newItem new item to add.
     */
-    function add(address[] storage self, address newItem)
-        internal
-    {
+    function add(address[] storage self, address newItem) internal {
         require(newItem != address(0x0), "EMPTY_ADDRESS_NOT_ALLOWED");
         self.push(newItem);
     }
@@ -23,9 +21,7 @@ library AddressArrayLib {
       @param self the current array.
       @param index remove an item in a specific index.
     */
-    function removeAt(address[] storage self, uint256 index)
-        internal
-    {
+    function removeAt(address[] storage self, uint256 index) internal {
         if (index >= self.length) return;
 
         if (index != self.length - 1) {
@@ -64,9 +60,7 @@ library AddressArrayLib {
       @param item the item to remove.
       @return the current array without the removed item.
     */
-    function remove(address[] storage self, address item)
-        internal
-    {
+    function remove(address[] storage self, address item) internal {
         (bool found, uint256 indexAt) = getIndex(self, item);
         if (!found) return self;
 

--- a/contracts/util/AddressArrayLib.sol
+++ b/contracts/util/AddressArrayLib.sol
@@ -10,28 +10,23 @@ library AddressArrayLib {
       @notice It adds an address value to the array.
       @param self current array.
       @param newItem new item to add.
-      @return the current array with the new item.
     */
     function add(address[] storage self, address newItem)
         internal
-        returns (address[] memory)
     {
         require(newItem != address(0x0), "EMPTY_ADDRESS_NOT_ALLOWED");
         self.push(newItem);
-        return self;
     }
 
     /**
       @notice It removes the value at the given index in an array.
       @param self the current array.
       @param index remove an item in a specific index.
-      @return the current array without the item removed.
     */
     function removeAt(address[] storage self, uint256 index)
         internal
-        returns (address[] memory)
     {
-        if (index >= self.length) return self;
+        if (index >= self.length) return;
 
         if (index != self.length - 1) {
             address temp = self[self.length - 1];
@@ -40,8 +35,6 @@ library AddressArrayLib {
 
         delete self[self.length - 1];
         self.length--;
-
-        return self;
     }
 
     /**
@@ -73,11 +66,10 @@ library AddressArrayLib {
     */
     function remove(address[] storage self, address item)
         internal
-        returns (address[] memory)
     {
         (bool found, uint256 indexAt) = getIndex(self, item);
         if (!found) return self;
 
-        return removeAt(self, indexAt);
+        removeAt(self, indexAt);
     }
 }


### PR DESCRIPTION
The AddressArrayLib functions take in `address[] storage`, meaning that it directly edits the array passed to it. This means that nothing needs to be returned from those functions as the arrays themselves have been edited and don't need to be re-assigned.