### PR TITLE
[PROTOCOL-410] [H01] Updating consensus unique identifier

### DIFF
--- a/contracts/base/InterestConsensus.sol
+++ b/contracts/base/InterestConsensus.sol
@@ -95,7 +95,7 @@ contract InterestConsensus is InterestConsensusInterface, Consensus {
         _validateResponse(
             response.signer,
             request.lender,
-            request.endTime,
+            request.requestNonce,
             response.responseTime,
             responseHash,
             response.signature

--- a/test/base/EstimateGasLoanTermsConsensusProcessRequestTest.js
+++ b/test/base/EstimateGasLoanTermsConsensusProcessRequestTest.js
@@ -27,7 +27,7 @@ contract('EstimateGasLoanTermsConsensusProcessRequestTest', function (accounts) 
     const owner = accounts[0];
     let instance
 
-    const baseGasCost = 510000;
+    const baseGasCost = 520000;
     const expectedGasCost = (responses) => baseGasCost + ((responses -  1) * 102000);
 
     let loans

--- a/test/base/InterestConsensusProcessResponseTest.js
+++ b/test/base/InterestConsensusProcessResponseTest.js
@@ -98,7 +98,7 @@ contract('InterestConsensusProcessResponseTest', function (accounts) {
             if (nodeIsSignerRole) {
                 await instance.addSigner(nodeAddress)
             }
-            await instance.mockHasSubmitted(nodeAddress, lender, endTime, mockHasSubmitted)
+            await instance.mockHasSubmitted(nodeAddress, lender, requestNonce, mockHasSubmitted)
             await instance.mockSignerNonce(nodeAddress, signerNonce, mockSignerNonceTaken)
             await instance.mockInterestSubmissions(
                 lender,


### PR DESCRIPTION
It is:
- Using the request.requestNonce parameter instead of the request.endTime parameter as the unique identifier to the _validateResponse function call in the call to the _processResponse function. 