### PR TITLE
[PROTOCOL-418] [L07] Misleading error messages

### DIFF
--- a/contracts/util/PlatformSettingsLib.sol
+++ b/contracts/util/PlatformSettingsLib.sol
@@ -29,8 +29,8 @@ library PlatformSettingsLib {
         uint256 max
     ) internal {
         requireNotExists(self);
-        require(value >= min, "VALUE_MUST_BE_GT_MIN_VALUE");
-        require(value <= max, "VALUE_MUST_BE_LT_MAX_VALUE");
+        require(value >= min, "VALUE_MUST_BE_GTE_MIN_VALUE");
+        require(value <= max, "VALUE_MUST_BE_LTE_MAX_VALUE");
         self.value = value;
         self.min = min;
         self.max = max;
@@ -70,8 +70,8 @@ library PlatformSettingsLib {
     {
         requireExists(self);
         require(self.value != newValue, "NEW_VALUE_REQUIRED");
-        require(newValue >= self.min, "NEW_VALUE_MUST_BE_GT_MIN_VALUE");
-        require(newValue <= self.max, "NEW_VALUE_MUST_BE_LT_MAX_VALUE");
+        require(newValue >= self.min, "NEW_VALUE_MUST_BE_GTE_MIN_VALUE");
+        require(newValue <= self.max, "NEW_VALUE_MUST_BE_LTE_MAX_VALUE");
         oldValue = self.value;
         self.value = newValue;
     }

--- a/test/base/EstimateGasLoanTermsConsensusProcessRequestTest.js
+++ b/test/base/EstimateGasLoanTermsConsensusProcessRequestTest.js
@@ -27,7 +27,7 @@ contract('EstimateGasLoanTermsConsensusProcessRequestTest', function (accounts) 
     const owner = accounts[0];
     let instance
 
-    const baseGasCost = 510000;
+    const baseGasCost = 520000;
     const expectedGasCost = (responses) => baseGasCost + ((responses -  1) * 102000);
 
     let loans

--- a/test/base/SettingsCreatePlatformSettingTest.js
+++ b/test/base/SettingsCreatePlatformSettingTest.js
@@ -33,13 +33,13 @@ contract('SettingsCreatePlatformSettingTest', function (accounts) {
             0, newSetting('mySetting', 1000, 0, 9000), undefined, false
         ],
         _2_invalid_value_lt_min: [
-            [], 0, newSetting('mySetting', 1000, 1001, 9000), 'VALUE_MUST_BE_GT_MIN_VALUE', true
+            [], 0, newSetting('mySetting', 1000, 1001, 9000), 'VALUE_MUST_BE_GTE_MIN_VALUE', true
         ],
         _3_valid_value_equal_min: [
             [], 0, newSetting('mySetting', 1000, 1000, 9000), undefined, false
         ],
         _4_invalid_value_gt_max: [
-            [], 0, newSetting('mySetting', 8501, 1000, 8500), 'VALUE_MUST_BE_LT_MAX_VALUE', true
+            [], 0, newSetting('mySetting', 8501, 1000, 8500), 'VALUE_MUST_BE_LTE_MAX_VALUE', true
         ],
         _5_valid_value_equal_max: [
             [], 0, newSetting('mySetting', 6000, 1000, 6000), undefined, false
@@ -66,11 +66,11 @@ contract('SettingsCreatePlatformSettingTest', function (accounts) {
         ],
         _9_invalid_max_value_overflow_uint256: [
             [],
-            0, newSetting('myCustomSettingB', 9000, 0, MAX_VALUE.plus(1)), 'VALUE_MUST_BE_LT_MAX_VALUE', true
+            0, newSetting('myCustomSettingB', 9000, 0, MAX_VALUE.plus(1)), 'VALUE_MUST_BE_LTE_MAX_VALUE', true
         ],
         _10_invalid_min_value_underflow_uint256: [
             [],
-            0, newSetting('myCustomSettingC', 9000, -1, 10000), 'VALUE_MUST_BE_GT_MIN_VALUE', true
+            0, newSetting('myCustomSettingC', 9000, -1, 10000), 'VALUE_MUST_BE_GTE_MIN_VALUE', true
         ],
         _11_invalid_empty_name: [
             [], 0, newSetting('', 1000, 1001, 9000), 'SETTING_NAME_MUST_BE_PROVIDED', true

--- a/test/base/SettingsUpdatePlatformSettingTest.js
+++ b/test/base/SettingsUpdatePlatformSettingTest.js
@@ -26,8 +26,8 @@ contract('SettingsUpdatePlatformSettingTest', function (accounts) {
 
     withData({
         _1_valid: [settingsNames.MaximumLoanDuration, 0, newSetting(1000, 0, 9000), 8100, undefined, false],
-        _2_invalid_not_lt_min: [settingsNames.MaximumLoanDuration, 0, newSetting(2000, 1500, 5000), 500, 'NEW_VALUE_MUST_BE_GT_MIN_VALUE', true],
-        _3_invalid_not_gt_max: [settingsNames.MaximumLoanDuration, 0, newSetting(1000, 500, 6000), 9000, 'NEW_VALUE_MUST_BE_LT_MAX_VALUE', true],
+        _2_invalid_not_lt_min: [settingsNames.MaximumLoanDuration, 0, newSetting(2000, 1500, 5000), 500, 'NEW_VALUE_MUST_BE_GTE_MIN_VALUE', true],
+        _3_invalid_not_gt_max: [settingsNames.MaximumLoanDuration, 0, newSetting(1000, 500, 6000), 9000, 'NEW_VALUE_MUST_BE_LTE_MAX_VALUE', true],
         _4_invalid_same_value: [settingsNames.MaximumLoanDuration, 0, newSetting(2000, 400, 6000), 2000, 'NEW_VALUE_REQUIRED', true],
         _5_invalid_not_owner: [settingsNames.MaximumLoanDuration, 1, newSetting(2000, 0, 7000), 5100, 'NOT_PAUSER', true],
     }, function(settingKey, senderIndex, currentValue, newValue, expectedErrorMessage, mustFail) {


### PR DESCRIPTION
It is:
- Updated error messages in the PlatformSettingsLib library to better reflect the code's behavior 