### PR TITLE
[PROTOCOL-425]: Fix N04 - mismatch between interface and implementation

### DIFF
--- a/contracts/interfaces/InterestConsensusInterface.sol
+++ b/contracts/interfaces/InterestConsensusInterface.sol
@@ -62,4 +62,14 @@ interface InterestConsensusInterface {
         address aCallerAddress,
         address aSettingAddress
     ) external;
+
+    function interestSubmissions(address, uint256)
+        external
+        view
+        returns (
+            uint256 count,
+            uint256 max,
+            uint256 min,
+            uint256 sum
+        );
 }

--- a/contracts/interfaces/InterestConsensusInterface.sol
+++ b/contracts/interfaces/InterestConsensusInterface.sol
@@ -66,10 +66,5 @@ interface InterestConsensusInterface {
     function interestSubmissions(address, uint256)
         external
         view
-        returns (
-            uint256 count,
-            uint256 max,
-            uint256 min,
-            uint256 sum
-        );
+        returns (NumbersList.Values memory);
 }

--- a/contracts/interfaces/SettingsInterface.sol
+++ b/contracts/interfaces/SettingsInterface.sol
@@ -241,23 +241,14 @@ interface SettingsInterface {
     function assetSettings(address)
         external
         view
-        returns (
-            address cTokenAddress,
-            uint256 maxLoanAmount,
-            bool initialized
-        );
+        returns (AssetSettingsLib.AssetSettings memory);
 
-    function assets() external view returns (address[] memory);
+    function assets(uint256) external view returns (address);
 
     function platformSettings(bytes32)
         external
         view
-        returns (
-            uint256 value,
-            uint256 min,
-            uint256 max,
-            bool exists
-        );
+        returns (PlatformSettingsLib.PlatformSetting memory);
 
     /**
         @notice Gets the current asset addresses list.

--- a/contracts/interfaces/SettingsInterface.sol
+++ b/contracts/interfaces/SettingsInterface.sol
@@ -238,6 +238,27 @@ interface SettingsInterface {
      */
     function updateCTokenAddress(address assetAddress, address newCTokenAddress) external;
 
+    function assetSettings(address)
+        external
+        view
+        returns (
+            address cTokenAddress,
+            uint256 maxLoanAmount,
+            bool initialized
+        );
+
+    function assets() external view returns (address[] memory);
+
+    function platformSettings(bytes32)
+        external
+        view
+        returns (
+            uint256 value,
+            uint256 min,
+            uint256 max,
+            bool exists
+        );
+
     /**
         @notice Gets the current asset addresses list.
         @return the asset addresses list.


### PR DESCRIPTION
Fills in the missing public getter functions from state variables.