### PR TITLE
[PROTOCOL-409] [C01]: Interest outcome can be manipulated

### DIFF
--- a/config/consts.js
+++ b/config/consts.js
@@ -1,30 +1,30 @@
-const { BigNumber,  } = require('bignumber.js');
+const {BigNumber} = require("bignumber.js");
 
-const MAX_VALUE = (new BigNumber(2).pow(256)).minus(1);
+const MAX_VALUE = new BigNumber(2).pow(256).minus(1);
 const maxValueString = MAX_VALUE.toFixed(0);
 
 module.exports = {
-    /**
+  /**
         As default this address is used to represent ETH.
      */
-    ETH_ADDRESS: '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE',
-    /*
+  ETH_ADDRESS: "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+  /*
         This address is ONLY used in network configurations where:
         1 - We have't deployed the contracts yet. Examples: mainnet.
         2- It is not possible to deploy third party contracts. Example: Chainlink in Ganache.
     */
-    DUMMY_ADDRESS: '0x0000000000000000000000000000000000000001',
-    /**
+  DUMMY_ADDRESS: "0x0000000000000000000000000000000000000001",
+  /**
         This is used as a default amount to configure max lending amount.
     */
-    DEFAULT_MAX_AMOUNT: 1000,
-    /**
-     * Represents the initial version of the Node Component.
-     * 
-     * e.g.: 10000 => represents : 1.00.00
-     */
-    INITIAL_NODE_COMPONENT_VERSION: 10000,
-    /**
+  DEFAULT_MAX_AMOUNT: 1000,
+  /**
+   * Represents the initial version of the Node Component.
+   *
+   * e.g.: 10000 => represents : 1.00.00
+   */
+  INITIAL_NODE_COMPONENT_VERSION: 10000,
+  /**
         The maximum tolerance is a percentage with 2 decimals.
         Examples:
             350 => 3.5%
@@ -32,19 +32,19 @@ module.exports = {
 
         The max value is 100% => 10000
     */
-    MAX_MAXIMUM_TOLERANCE_VALUE: 10000,
-    /**
+  MAX_MAXIMUM_TOLERANCE_VALUE: 10000,
+  /**
         The max value for a uint256 (solidity type)
         It is used as a max value for some settings.
     */
-    MAX_VALUE,
-    MAX_VALUE_STRING: maxValueString,
-    DEFAULT_REQUIRED_SUBMISSIONS: 7,
-    DEFAULT_MAXIMUM_TOLERANCE: 0,
-    DEFAULT_RESPONSE_EXPIRY: 2592000, // 30 day,
-    DEFAULT_SAFETY_INTERVAL: 300,  // 5 minute,
-    DEFAULT_TERMS_EXPIRY_TIME: 2592000, // 30 day,
-    DEFAULT_LIQUIDATE_ETH_PRICE: 9500, // 95%,
-    DEFAULT_STARTING_BLOCK_OFFSET_NUMBER: 40,
-    DEFAULT_COLLATERAL_BUFFER: 1500, // 15%
-}
+  MAX_VALUE,
+  MAX_VALUE_STRING: maxValueString,
+  DEFAULT_REQUIRED_SUBMISSIONS_PERCENTAGE: 8000,
+  DEFAULT_MAXIMUM_TOLERANCE: 0,
+  DEFAULT_RESPONSE_EXPIRY: 2592000, // 30 day,
+  DEFAULT_SAFETY_INTERVAL: 300, // 5 minute,
+  DEFAULT_TERMS_EXPIRY_TIME: 2592000, // 30 day,
+  DEFAULT_LIQUIDATE_ETH_PRICE: 9500, // 95%,
+  DEFAULT_STARTING_BLOCK_OFFSET_NUMBER: 40,
+  DEFAULT_COLLATERAL_BUFFER: 1500, // 15%
+};

--- a/config/networks/ganache-mainnet/platformSettings.json
+++ b/config/networks/ganache-mainnet/platformSettings.json
@@ -1,9 +1,9 @@
 {
-  "RequiredSubmissions": {
+  "RequiredSubmissionsPercentage": {
     "processOnDeployment": true,
-    "value": 2,
+    "value": 8000,
     "min": 0,
-    "max": "115792089237316195423570985008687907853269984665640564039457584007913129639935"
+    "max": 10000
   },
   "MaximumTolerance": {
     "processOnDeployment": true,

--- a/config/networks/kovan/platformSettings.json
+++ b/config/networks/kovan/platformSettings.json
@@ -1,9 +1,9 @@
 {
-  "RequiredSubmissions": {
+  "RequiredSubmissionsPercentage": {
     "processOnDeployment": true,
-    "value": 1,
-    "min": 1,
-    "max": "115792089237316195423570985008687907853269984665640564039457584007913129639935"
+    "value": 8000,
+    "min": 0,
+    "max": 10000
   },
   "MaximumTolerance": {
     "processOnDeployment": true,

--- a/config/networks/mainnet/platformSettings.json
+++ b/config/networks/mainnet/platformSettings.json
@@ -1,9 +1,9 @@
 {
-  "RequiredSubmissions": {
+  "RequiredSubmissionsPercentage": {
     "processOnDeployment": true,
-    "value": 1,
+    "value": 8000,
     "min": 0,
-    "max": "115792089237316195423570985008687907853269984665640564039457584007913129639935"
+    "max": 10000
   },
   "MaximumTolerance": {
     "processOnDeployment": true,

--- a/config/networks/rinkeby/platformSettings.json
+++ b/config/networks/rinkeby/platformSettings.json
@@ -1,9 +1,9 @@
 {
-  "RequiredSubmissions": {
+  "RequiredSubmissionsPercentage": {
     "processOnDeployment": true,
-    "value": 1,
+    "value": 8000,
     "min": 0,
-    "max": "115792089237316195423570985008687907853269984665640564039457584007913129639935"
+    "max": 10000
   },
   "MaximumTolerance": {
     "processOnDeployment": true,

--- a/config/networks/ropsten/platformSettings.json
+++ b/config/networks/ropsten/platformSettings.json
@@ -1,9 +1,9 @@
 {
-  "RequiredSubmissions": {
+  "RequiredSubmissionsPercentage": {
     "processOnDeployment": true,
-    "value": 1,
+    "value": 8000,
     "min": 0,
-    "max": "115792089237316195423570985008687907853269984665640564039457584007913129639935"
+    "max": 10000
   },
   "MaximumTolerance": {
     "processOnDeployment": true,

--- a/config/networks/soliditycoverage/platformSettings.json
+++ b/config/networks/soliditycoverage/platformSettings.json
@@ -1,9 +1,9 @@
 {
-  "RequiredSubmissions": {
+  "RequiredSubmissionsPercentage": {
     "processOnDeployment": true,
-    "value": 2,
+    "value": 8000,
     "min": 0,
-    "max": "115792089237316195423570985008687907853269984665640564039457584007913129639935"
+    "max": 10000
   },
   "MaximumTolerance": {
     "processOnDeployment": true,

--- a/config/networks/test/platformSettings.json
+++ b/config/networks/test/platformSettings.json
@@ -1,7 +1,7 @@
 {
-  "RequiredSubmissions": {
+  "RequiredSubmissionsPercentage": {
     "processOnDeployment": true,
-    "value": 2,
+    "value": 8000,
     "min": 0,
     "max": "115792089237316195423570985008687907853269984665640564039457584007913129639935"
   },

--- a/config/networks/test/platformSettings.json
+++ b/config/networks/test/platformSettings.json
@@ -3,7 +3,7 @@
     "processOnDeployment": true,
     "value": 8000,
     "min": 0,
-    "max": "115792089237316195423570985008687907853269984665640564039457584007913129639935"
+    "max": 10000
   },
   "MaximumTolerance": {
     "processOnDeployment": true,

--- a/contracts/base/Consensus.sol
+++ b/contracts/base/Consensus.sol
@@ -60,18 +60,22 @@ contract Consensus is Base, OwnerSignersRole {
         _;
     }
 
+    /**
+        @notice Checks if the number of responses is greater or equal to a percentage of
+        the number of signers.
+     */
     modifier onlyEnoughSubmissions(uint256 responseCount) {
+        SettingsInterface settings = _getSettings();
+        uint256 percentageRequired = settings
+            .platformSettings(settings.consts().REQUIRED_SUBMISSIONS_PERCENTAGE_SETTING())
+            .value;
+        // https://stackoverflow.com/questions/17005364/dividing-two-integers-and-rounding-up-the-result-without-using-floating-point
+        uint256 minimumResponseCount = _signerCount.mul(percentageRequired).add(9999).div(
+            10000
+        );
+
         require(
-            responseCount >=
-                _signerCount
-                    .mul(
-                    _getSettings()
-                        .platformSettings(
-                        _getSettings().consts().REQUIRED_SUBMISSIONS_PERCENTAGE_SETTING()
-                    )
-                        .value
-                )
-                    .div(10000),
+            responseCount >= minimumResponseCount,
             "INSUFFICIENT_NUMBER_OF_RESPONSES"
         );
         _;

--- a/contracts/base/Consensus.sol
+++ b/contracts/base/Consensus.sol
@@ -60,6 +60,11 @@ contract Consensus is Base, OwnerSignersRole {
         _;
     }
 
+    modifier onlyEnoughSubmissions(uint256 responseCount) {
+        require(responseCount >= _signerCount - 1, "INSUFFICIENT_NUMBER_OF_RESPONSES");
+        _;
+    }
+
     /**
         @notice It initializes this consensus contract.
         @dev The caller address must be the loans contract for LoanTermsConsensus, and the lenders contract for InterestConsensus.

--- a/contracts/base/Consensus.sol
+++ b/contracts/base/Consensus.sol
@@ -30,6 +30,7 @@ import "../base/Base.sol";
 contract Consensus is Base, OwnerSignersRole {
     using SafeMath for uint256;
     using NumbersList for NumbersList.Values;
+    using NumbersLib for uint256;
 
     // Has signer address already submitted their answer for (user, identifier)?
     mapping(address => mapping(address => mapping(uint256 => bool))) public hasSubmitted;
@@ -65,17 +66,15 @@ contract Consensus is Base, OwnerSignersRole {
         the number of signers.
      */
     modifier onlyEnoughSubmissions(uint256 responseCount) {
-        SettingsInterface settings = _getSettings();
-        uint256 percentageRequired = settings
-            .platformSettings(settings.consts().REQUIRED_SUBMISSIONS_PERCENTAGE_SETTING())
+        uint256 percentageRequired =_getSettings()
+            .platformSettings(
+                _getSettings().consts().REQUIRED_SUBMISSIONS_PERCENTAGE_SETTING()
+            )
             .value;
-        // https://stackoverflow.com/questions/17005364/dividing-two-integers-and-rounding-up-the-result-without-using-floating-point
-        uint256 minimumResponseCount = _signerCount.mul(percentageRequired).add(9999).div(
-            10000
-        );
+
 
         require(
-            responseCount >= minimumResponseCount,
+            responseCount.ratioOf(_signerCount) >= percentageRequired,
             "INSUFFICIENT_NUMBER_OF_RESPONSES"
         );
         _;

--- a/contracts/base/Consensus.sol
+++ b/contracts/base/Consensus.sol
@@ -61,7 +61,19 @@ contract Consensus is Base, OwnerSignersRole {
     }
 
     modifier onlyEnoughSubmissions(uint256 responseCount) {
-        require(responseCount >= _signerCount - 1, "INSUFFICIENT_NUMBER_OF_RESPONSES");
+        require(
+            responseCount >=
+                _signerCount
+                    .mul(
+                    _getSettings()
+                        .platformSettings(
+                        _getSettings().consts().REQUIRED_SUBMISSIONS_PERCENTAGE_SETTING()
+                    )
+                        .value
+                )
+                    .div(10000),
+            "INSUFFICIENT_NUMBER_OF_RESPONSES"
+        );
         _;
     }
 

--- a/contracts/base/InterestConsensus.sol
+++ b/contracts/base/InterestConsensus.sol
@@ -44,14 +44,13 @@ contract InterestConsensus is InterestConsensusInterface, Consensus {
     function processRequest(
         TellerCommon.InterestRequest calldata request,
         TellerCommon.InterestResponse[] calldata responses
-    ) external isInitialized() isCaller(msg.sender) returns (uint256) {
-        require(
-            responses.length >=
-                _getSettings().getPlatformSettingValue(
-                    _getSettings().consts().REQUIRED_SUBMISSIONS_SETTING()
-                ),
-            "INTEREST_INSUFFICIENT_RESPONSES"
-        );
+    )
+        external
+        isInitialized()
+        isCaller(msg.sender)
+        onlyEnoughSubmissions(responses.length)
+        returns (uint256)
+    {
         require(
             !requestNonceTaken[request.lender][request.requestNonce],
             "INTEREST_REQUEST_NONCE_TAKEN"

--- a/contracts/base/LoanTermsConsensus.sol
+++ b/contracts/base/LoanTermsConsensus.sol
@@ -59,19 +59,13 @@ contract LoanTermsConsensus is LoanTermsConsensusInterface, Consensus {
         external
         isInitialized()
         isCaller(msg.sender)
+        onlyEnoughSubmissions(responses.length)
         returns (
             uint256 interestRate,
             uint256 collateralRatio,
             uint256 maxLoanAmount
         )
     {
-        require(
-            responses.length >=
-                _getSettings().getPlatformSettingValue(
-                    _getSettings().consts().REQUIRED_SUBMISSIONS_SETTING()
-                ),
-            "LOANTERM_INSUFFICIENT_RESPONSES"
-        );
         _requireRequestLoanTermsRateLimit(request);
         require(
             !requestNonceTaken[request.borrower][request.requestNonce],

--- a/contracts/base/OwnerSignersRole.sol
+++ b/contracts/base/OwnerSignersRole.sol
@@ -27,6 +27,8 @@ contract OwnerSignersRole is Ownable {
 
     Roles.Role private _signers;
 
+    uint256 public _signerCount;
+
     /**
         @notice Gets whether an account address is a signer or not.
         @param account address to test.
@@ -44,6 +46,7 @@ contract OwnerSignersRole is Ownable {
      */
     function addSigner(address account) public onlyOwner {
         _addSigner(account);
+        _signerCount++;
     }
 
     /**
@@ -70,6 +73,7 @@ contract OwnerSignersRole is Ownable {
      */
     function removeSigner(address account) public onlyOwner {
         _removeSigner(account);
+        _signerCount--;
     }
 
     /**

--- a/contracts/util/SettingsConsts.sol
+++ b/contracts/util/SettingsConsts.sol
@@ -17,9 +17,10 @@ contract SettingsConsts {
 
     /**
         @notice The setting name for the required subsmission settings.
-        @notice This is the minimum number of node responses that will be required by the platform to either take out a loan, and to claim accrued interest. If the number of node responses are less than the ones specified here, the loan or accrued interest claim request will be rejected by the platform
+        @notice This is the minimum percentage of node responses that will be required by the platform to either take out a loan, and to claim accrued interest. If the number of node responses are less than the ones specified here, the loan or accrued interest claim request will be rejected by the platform
      */
-    bytes32 public constant REQUIRED_SUBMISSIONS_SETTING = "RequiredSubmissions";
+    bytes32
+        public constant REQUIRED_SUBMISSIONS_PERCENTAGE_SETTING = "RequiredSubmissionsPercentage";
     /**
         @notice The setting name for the maximum tolerance settings.
         @notice This is the maximum tolerance for the values submitted (by nodes) when they are aggregated (average). It is used in the consensus mechanisms.

--- a/scripts/utils/cli/names.js
+++ b/scripts/utils/cli/names.js
@@ -1,230 +1,230 @@
 const DEFAULT_SIGNER_URLS = [
-    // TODO Sets the default URLs once we have them
+  // TODO Sets the default URLs once we have them
 ];
 const DEFAULT_SIGNER_ADDRESSES = [
-    '0xE8bF0ceF0Bf531Fd56081Ad0B85706cE37A7FD34',
-    '0x34fA03245325fd8cf67C694685932B73aC73666C',
-    '0x981D72d7E8dCaeae14D10db3A94f50958904C117',
-    '0xa75f98d2566673De80Ac4169Deab45c6adad3164',
-    '0x924Af6Cfa15F76E04763D9e24a1c892fD7767983',
-    '0x3Eb394E83f82be8ed7ac86aF0DcbdaE4890Be307',
+  "0xE8bF0ceF0Bf531Fd56081Ad0B85706cE37A7FD34",
+  "0x34fA03245325fd8cf67C694685932B73aC73666C",
+  "0x981D72d7E8dCaeae14D10db3A94f50958904C117",
+  "0xa75f98d2566673De80Ac4169Deab45c6adad3164",
+  "0x924Af6Cfa15F76E04763D9e24a1c892fD7767983",
+  "0x3Eb394E83f82be8ed7ac86aF0DcbdaE4890Be307",
 ];
-const DEFAULT_COLLATERAL_TOKEN_NAME = 'ETH';
-const DEFAULT_TEST_TOKEN_NAME = 'DAI';
-const DEFAULT_TOKEN_NAMES = ['DAI', 'USDC'];
-const DEFAULT_COLL_TOKEN_NAMES = ['ETH', 'LINK'];
-const DEFAULT_REQUIRED_SUBMISSIONS = 2;
+const DEFAULT_COLLATERAL_TOKEN_NAME = "ETH";
+const DEFAULT_TEST_TOKEN_NAME = "DAI";
+const DEFAULT_TOKEN_NAMES = ["DAI", "USDC"];
+const DEFAULT_COLL_TOKEN_NAMES = ["ETH", "LINK"];
+const DEFAULT_REQUIRED_SUBMISSIONS_PERCENTAGE = 8000;
 const DEFAULT_SAFETY_INTERVAL = 1;
 
 module.exports = {
-    NETWORK: {
-        name: 'network',
-        alias: 'N',
-        default: undefined,
-    },
-    TOKEN_NAME: {
-        name: 'tokenName',
-        alias: 'TN',
-        default: 'DAI',
-    },
-    COLL_TOKEN_NAME: {
-        name: 'collTokenName',
-        alias: 'CTN',
-        default: DEFAULT_COLLATERAL_TOKEN_NAME,
-    },
-    COLL_TOKEN_NAMES: {
-        name: 'collTokenNames',
-        alias: 'CTNS',
-        default: DEFAULT_COLL_TOKEN_NAMES,
-    },
-    BASE_TOKEN_NAME: {
-        name: 'baseTokenName',
-        alias: 'BTN',
-        default: undefined
-    },
-    QUOTE_TOKEN_NAME: {
-        name: 'quoteTokenName',
-        alias: 'QTN',
-        default: undefined
-    },
-    SENDER_INDEX: {
-        name: 'senderIndex',
-        alias: 'SI',
-        default: 0,
-    },
-    RECEIVER_INDEX: {
-        name: 'receiverIndex',
-        alias: 'RI',
-        default: 1,
-    },
-    AMOUNT: {
-        name: 'amount',
-        alias: 'A',
-        default: 100,
-    },
-    NEW_VALUE: {
-        name: 'newValue',
-        alias: 'NV',
-        default: undefined,
-    },
-    LOAN_ID: {
-        name: 'loanId',
-        alias: 'LI',
-        default: undefined,
-    },
-    SETTING_NAME: {
-        name: 'settingName',
-        alias: 'SN',
-        default: undefined,
-    },
-    ASSET_SETTING_NAME: {
-        name: 'assetSettingName',
-        alias: 'ASN',
-        default: undefined,
-    },
-    CTOKEN_NAME: {
-        name: 'cTokenName',
-        alias: 'CTN',
-        default: undefined,
-    },
-    BORROWER_INDEX: {
-        name: 'borrowerIndex',
-        alias: 'BI',
-        default: 0,
-    },
-    INITIAL_LOAN_ID: {
-        name: 'initialLoanId',
-        alias: 'ILI',
-        default: 0,
-    },
-    FINAL_LOAN_ID: {
-        name: 'finalLoanId',
-        alias: 'FLI',
-        default: 10000,
-    },
-    RECIPIENT_INDEX: {
-        name: 'recipientIndex',
-        alias: 'RI',
-        default: -1,
-    },
-    DURATION_DAYS: {
-        name: 'durationDays',
-        alias: 'DD',
-        default: 10,
-    },
-    BORROWER: {
-        name: 'borrower',
-        alias: 'B',
-        default: undefined,
-    },
-    SECONDS: {
-        name: 'seconds',
-        alias: 'S',
-        default: 60 * 2,
-    },
-    COLL_AMOUNT: {
-        name: 'collAmount',
-        alias: 'CA',
-        default: 0,
-    },
-    NONCE: {
-        name: 'nonce',
-        alias: 'NN',
-        default: 0,
-    },
-    ADDRESSES: {
-        name: 'addresses',
-        alias: 'AA',
-        default: undefined,
-    },
-    ACCOUNT_INDEX: {
-        name: 'accountIndex',
-        alias: 'AI',
-        default: 0,
-    },
-    REVERT: {
-        name: 'revert',
-        alias: 'R',
-        default: false,
-    },
-    REVERT_TEST: {
-        name: 'revertTest',
-        alias: 'RT',
-        default: false,
-    },
-    INITIAL_NONCE: {
-        name: 'initialNonce',
-        alias: 'IN',
-        default: 0,
-    },
-    SIGNER_ADDRESS: {
-        name: 'signerAddress',
-        alias: 'SA',
-        default: DEFAULT_SIGNER_ADDRESSES,
-    },
-    SIGNER_URL: {
-        name: 'signerUrl',
-        alias: 'SU',
-        default: DEFAULT_SIGNER_URLS,
-    },
-    TOKEN_NAMES: {
-        name: 'tokenNames',
-        alias: 'TNS',
-        default: DEFAULT_TOKEN_NAMES,
-    },
-    REQUIRED_SUBMISSIONS: {
-        name: 'requiredSubmissions',
-        alias: 'RS',
-        default: DEFAULT_REQUIRED_SUBMISSIONS,
-    },
-    SAFETY_INTERVAL: {
-        name: 'safetyInterval',
-        alias: 'SI',
-        default: DEFAULT_SAFETY_INTERVAL,
-    },
-    TEST_TOKEN_NAME: {
-        name: 'testTokenName',
-        alias: 'TTN',
-        default: DEFAULT_TEST_TOKEN_NAME,
-    },
-    MAX_LOAN_AMOUNT: {
-        name: 'maxLoanAmount',
-        alias: 'MLA',
-        default: undefined,
-    },
-    MAX_VALUE: {
-        name: 'maxValue',
-        alias: 'MAV',
-        default: undefined,
-    },
-    MIN_VALUE: {
-        name: 'minValue',
-        alias: 'MIV',
-        default: 0,
-    },
-    BACK_ROUNDS: {
-        name: 'backRounds',
-        alias: 'BR',
-        default: 0,
-    },
-    MIN_AMOUNT: {
-        name: 'minAmount',
-        alias: 'MA',
-        default: undefined,
-    },
-    LOGIC_NAME: {
-        name: 'logicName',
-        alias: 'LN',
-        default: undefined,
-    },
-    CONTRACT_NAME: {
-        name: 'contractName',
-        alias: 'CN',
-        default: undefined,
-    },
-    VERBOSE: {
-        name: 'verbose',
-        alias: 'V',
-        default: false,
-    },
+  NETWORK: {
+    name: "network",
+    alias: "N",
+    default: undefined,
+  },
+  TOKEN_NAME: {
+    name: "tokenName",
+    alias: "TN",
+    default: "DAI",
+  },
+  COLL_TOKEN_NAME: {
+    name: "collTokenName",
+    alias: "CTN",
+    default: DEFAULT_COLLATERAL_TOKEN_NAME,
+  },
+  COLL_TOKEN_NAMES: {
+    name: "collTokenNames",
+    alias: "CTNS",
+    default: DEFAULT_COLL_TOKEN_NAMES,
+  },
+  BASE_TOKEN_NAME: {
+    name: "baseTokenName",
+    alias: "BTN",
+    default: undefined,
+  },
+  QUOTE_TOKEN_NAME: {
+    name: "quoteTokenName",
+    alias: "QTN",
+    default: undefined,
+  },
+  SENDER_INDEX: {
+    name: "senderIndex",
+    alias: "SI",
+    default: 0,
+  },
+  RECEIVER_INDEX: {
+    name: "receiverIndex",
+    alias: "RI",
+    default: 1,
+  },
+  AMOUNT: {
+    name: "amount",
+    alias: "A",
+    default: 100,
+  },
+  NEW_VALUE: {
+    name: "newValue",
+    alias: "NV",
+    default: undefined,
+  },
+  LOAN_ID: {
+    name: "loanId",
+    alias: "LI",
+    default: undefined,
+  },
+  SETTING_NAME: {
+    name: "settingName",
+    alias: "SN",
+    default: undefined,
+  },
+  ASSET_SETTING_NAME: {
+    name: "assetSettingName",
+    alias: "ASN",
+    default: undefined,
+  },
+  CTOKEN_NAME: {
+    name: "cTokenName",
+    alias: "CTN",
+    default: undefined,
+  },
+  BORROWER_INDEX: {
+    name: "borrowerIndex",
+    alias: "BI",
+    default: 0,
+  },
+  INITIAL_LOAN_ID: {
+    name: "initialLoanId",
+    alias: "ILI",
+    default: 0,
+  },
+  FINAL_LOAN_ID: {
+    name: "finalLoanId",
+    alias: "FLI",
+    default: 10000,
+  },
+  RECIPIENT_INDEX: {
+    name: "recipientIndex",
+    alias: "RI",
+    default: -1,
+  },
+  DURATION_DAYS: {
+    name: "durationDays",
+    alias: "DD",
+    default: 10,
+  },
+  BORROWER: {
+    name: "borrower",
+    alias: "B",
+    default: undefined,
+  },
+  SECONDS: {
+    name: "seconds",
+    alias: "S",
+    default: 60 * 2,
+  },
+  COLL_AMOUNT: {
+    name: "collAmount",
+    alias: "CA",
+    default: 0,
+  },
+  NONCE: {
+    name: "nonce",
+    alias: "NN",
+    default: 0,
+  },
+  ADDRESSES: {
+    name: "addresses",
+    alias: "AA",
+    default: undefined,
+  },
+  ACCOUNT_INDEX: {
+    name: "accountIndex",
+    alias: "AI",
+    default: 0,
+  },
+  REVERT: {
+    name: "revert",
+    alias: "R",
+    default: false,
+  },
+  REVERT_TEST: {
+    name: "revertTest",
+    alias: "RT",
+    default: false,
+  },
+  INITIAL_NONCE: {
+    name: "initialNonce",
+    alias: "IN",
+    default: 0,
+  },
+  SIGNER_ADDRESS: {
+    name: "signerAddress",
+    alias: "SA",
+    default: DEFAULT_SIGNER_ADDRESSES,
+  },
+  SIGNER_URL: {
+    name: "signerUrl",
+    alias: "SU",
+    default: DEFAULT_SIGNER_URLS,
+  },
+  TOKEN_NAMES: {
+    name: "tokenNames",
+    alias: "TNS",
+    default: DEFAULT_TOKEN_NAMES,
+  },
+  REQUIRED_SUBMISSIONS_PERCENTAGE: {
+    name: "requiredSubmissionsPercentage",
+    alias: "RSP",
+    default: DEFAULT_REQUIRED_SUBMISSIONS_PERCENTAGE,
+  },
+  SAFETY_INTERVAL: {
+    name: "safetyInterval",
+    alias: "SI",
+    default: DEFAULT_SAFETY_INTERVAL,
+  },
+  TEST_TOKEN_NAME: {
+    name: "testTokenName",
+    alias: "TTN",
+    default: DEFAULT_TEST_TOKEN_NAME,
+  },
+  MAX_LOAN_AMOUNT: {
+    name: "maxLoanAmount",
+    alias: "MLA",
+    default: undefined,
+  },
+  MAX_VALUE: {
+    name: "maxValue",
+    alias: "MAV",
+    default: undefined,
+  },
+  MIN_VALUE: {
+    name: "minValue",
+    alias: "MIV",
+    default: 0,
+  },
+  BACK_ROUNDS: {
+    name: "backRounds",
+    alias: "BR",
+    default: 0,
+  },
+  MIN_AMOUNT: {
+    name: "minAmount",
+    alias: "MA",
+    default: undefined,
+  },
+  LOGIC_NAME: {
+    name: "logicName",
+    alias: "LN",
+    default: undefined,
+  },
+  CONTRACT_NAME: {
+    name: "contractName",
+    alias: "CN",
+    default: undefined,
+  },
+  VERBOSE: {
+    name: "verbose",
+    alias: "V",
+    default: false,
+  },
 };

--- a/scripts/utils/cli/params.js
+++ b/scripts/utils/cli/params.js
@@ -26,7 +26,7 @@ const {
   SIGNER_ADDRESS,
   SIGNER_URL,
   TOKEN_NAMES,
-  REQUIRED_SUBMISSIONS,
+  REQUIRED_SUBMISSIONS_PERCENTAGE,
   SAFETY_INTERVAL,
   TEST_TOKEN_NAME,
   MAX_LOAN_AMOUNT,
@@ -213,7 +213,10 @@ module.exports.addCTokenName = (yargs, defaultParam = CTOKEN_NAME.default) => {
   );
 };
 
-module.exports.addMaxLoanAmount = (yargs, defaultParam = MAX_LOAN_AMOUNT.default) => {
+module.exports.addMaxLoanAmount = (
+  yargs,
+  defaultParam = MAX_LOAN_AMOUNT.default
+) => {
   newOption(
     yargs,
     MAX_LOAN_AMOUNT.name,
@@ -410,7 +413,10 @@ module.exports.addRevertTest = (yargs, defaultParam = REVERT_TEST.default) => {
   );
 };
 
-module.exports.addCollTokenNames = (yargs, defaultParam = COLL_TOKEN_NAMES.default) => {
+module.exports.addCollTokenNames = (
+  yargs,
+  defaultParam = COLL_TOKEN_NAMES.default
+) => {
   newOption(
     yargs,
     COLL_TOKEN_NAMES.name,
@@ -473,12 +479,12 @@ module.exports.addTokenNames = (yargs, defaultParam = TOKEN_NAMES.default) => {
 
 module.exports.addRequiredSubmissions = (
   yargs,
-  defaultParam = REQUIRED_SUBMISSIONS.default
+  defaultParam = REQUIRED_SUBMISSIONS_PERCENTAGE.default
 ) => {
   newOption(
     yargs,
-    REQUIRED_SUBMISSIONS.name,
-    REQUIRED_SUBMISSIONS.alias,
+    REQUIRED_SUBMISSIONS_PERCENTAGE.name,
+    REQUIRED_SUBMISSIONS_PERCENTAGE.alias,
     "number",
     `Used to set as min required (responses) submissions when a borrower asks to node validators to sign responses. By default ${defaultParam}`,
     defaultParam
@@ -499,10 +505,7 @@ module.exports.addSafetyInterval = (
   );
 };
 
-module.exports.addMinAmount = (
-  yargs,
-  defaultParam = MIN_AMOUNT.default
-) => {
+module.exports.addMinAmount = (yargs, defaultParam = MIN_AMOUNT.default) => {
   newOption(
     yargs,
     MIN_AMOUNT.name,
@@ -524,7 +527,10 @@ module.exports.addLogicName = (yargs, defaultParam = LOGIC_NAME.default) => {
   );
 };
 
-module.exports.addContractName = (yargs, defaultParam = CONTRACT_NAME.default) => {
+module.exports.addContractName = (
+  yargs,
+  defaultParam = CONTRACT_NAME.default
+) => {
   newOption(
     yargs,
     CONTRACT_NAME.name,

--- a/test-integration/initializers/1_set_settings.js
+++ b/test-integration/initializers/1_set_settings.js
@@ -8,16 +8,16 @@ module.exports = async (initConfig, { accounts, getContracts, web3 }) => {
   const txConfig = await accounts.getTxConfigAt(0);
   const settings = await getContracts.getDeployed(teller.settings());
   const {
-    requiredSubmissions,
+    requiredSubmissionsPercentage,
     safetyInterval,
   } = initConfig;
-  const requiredSubmissionsBytes32 = toBytes32(web3, platformSettingsNames.RequiredSubmissions);
-  const currentRequiredSubmissions = await settings.getPlatformSettingValue(requiredSubmissionsBytes32, txConfig);
-  if (requiredSubmissions !== parseInt(currentRequiredSubmissions)) {
-    await settings.updatePlatformSetting(requiredSubmissionsBytes32, requiredSubmissions, txConfig);
+  const requiredSubmissionsPercentageBytes32 = toBytes32(web3, platformSettingsNames.RequiredSubmissionsPercentage);
+  const currentRequiredSubmissionsPercentage = await settings.getPlatformSettingValue(requiredSubmissionsPercentageBytes32, txConfig);
+  if (requiredSubmissionsPercentage !== parseInt(currentRequiredSubmissionsPercentage)) {
+    await settings.updatePlatformSetting(requiredSubmissionsPercentageBytes32, requiredSubmissionsPercentage, txConfig);
   }
-  const updatedRequiredSubmissions = await settings.getPlatformSettingValue(requiredSubmissionsBytes32, txConfig);
-  console.log(`Settings >> New Required Submissions:   ${updatedRequiredSubmissions.toString()}`);
+  const updatedRequiredSubmissionsPercentage = await settings.getPlatformSettingValue(requiredSubmissionsPercentageBytes32, txConfig);
+  console.log(`Settings >> New Required Submissions:   ${updatedRequiredSubmissionsPercentage.toString()}`);
 
   const safetyIntervalBytes32 = toBytes32(web3, platformSettingsNames.SafetyInterval);
   const currentSafetyInterval = await settings.getPlatformSettingValue(safetyIntervalBytes32, txConfig);

--- a/test/base/EstimateGasInterestConsensusProcessRequestTest.js
+++ b/test/base/EstimateGasInterestConsensusProcessRequestTest.js
@@ -1,17 +1,11 @@
-const withData = require('leche').withData;
-const { createTestSettingsInstance } = require('../utils/settings-helper');
-const settingsNames = require('../utils/platformSettingsNames');
-const { 
-    t,
-    getLatestTimestamp,
-    ONE_DAY,
-    THIRTY_DAYS,
-    NULL_ADDRESS,
-} = require('../utils/consts');
-const { createInterestRequest, createUnsignedInterestResponse } = require('../utils/structs');
-const { createInterestResponseSig, hashInterestRequest } = require('../utils/hashes');
-const ethUtil = require('ethereumjs-util');
-const chains = require('../utils/chains');
+const withData = require("leche").withData;
+const {createTestSettingsInstance} = require("../utils/settings-helper");
+const settingsNames = require("../utils/platformSettingsNames");
+const {t, getLatestTimestamp, ONE_DAY, THIRTY_DAYS, NULL_ADDRESS} = require("../utils/consts");
+const {createInterestRequest, createUnsignedInterestResponse} = require("../utils/structs");
+const {createInterestResponseSig, hashInterestRequest} = require("../utils/hashes");
+const ethUtil = require("ethereumjs-util");
+const chains = require("../utils/chains");
 
 // Mock contracts
 const Mock = artifacts.require("./mock/util/Mock.sol");
@@ -20,57 +14,57 @@ const Mock = artifacts.require("./mock/util/Mock.sol");
 const Settings = artifacts.require("./base/Settings.sol");
 const InterestConsensus = artifacts.require("./mock/base/InterestConsensusMock.sol");
 
-contract('EstimateGasInterestConsensusProcessRequestTest', function (accounts) {
+contract("EstimateGasInterestConsensusProcessRequestTest", function (accounts) {
     const owner = accounts[0];
     let lenders;
-    let instance
-    const nodeOne = accounts[1]
-    const nodeTwo = accounts[2]
-    const nodeThree = accounts[3]
-    const nodeFour = accounts[4]
-    const nodeFive = accounts[5]
-    const nodeSix = accounts[6]
-    const nodeSeven = accounts[7]
-    const nodeEight = accounts[8]
-    const nodeNine = accounts[9]
-    const lender = accounts[9]
-    const endTime = 34567
+    let instance;
+    const nodeOne = accounts[1];
+    const nodeTwo = accounts[2];
+    const nodeThree = accounts[3];
+    const nodeFour = accounts[4];
+    const nodeFive = accounts[5];
+    const nodeSix = accounts[6];
+    const nodeSeven = accounts[7];
+    const nodeEight = accounts[8];
+    const nodeNine = accounts[9];
+    const lender = accounts[9];
+    const endTime = 34567;
 
     let currentTime;
     let interestRequest;
 
     const baseGasCost = 266000;
-    const expectedGasCost = (responses) => baseGasCost + ((responses -  1) * 85500);
+    const expectedGasCost = (responses) => baseGasCost + (responses - 1) * 85500;
 
-    let responseOne = createUnsignedInterestResponse(nodeOne, 0, 34676, 1, NULL_ADDRESS)
-    let responseTwo = createUnsignedInterestResponse(nodeTwo, 0, 34642, 1, NULL_ADDRESS)
-    let responseThree = createUnsignedInterestResponse(nodeThree, 0, 34632, 1, NULL_ADDRESS)
-    let responseFour = createUnsignedInterestResponse(nodeFour, 0, 34620, 1, NULL_ADDRESS)
-    let responseFive = createUnsignedInterestResponse(nodeFive, 0, 34636, 1, NULL_ADDRESS)
-    let responseSix = createUnsignedInterestResponse(nodeSix, 0, 34636, 1, NULL_ADDRESS)
-    let responseSeven = createUnsignedInterestResponse(nodeSeven, 0, 34636, 1, NULL_ADDRESS)
-    let responseEight = createUnsignedInterestResponse(nodeEight, 0, 34636, 1, NULL_ADDRESS)
-    let responseNine = createUnsignedInterestResponse(nodeNine, 0, 34636, 1, NULL_ADDRESS)
+    let responseOne = createUnsignedInterestResponse(nodeOne, 0, 34676, 1, NULL_ADDRESS);
+    let responseTwo = createUnsignedInterestResponse(nodeTwo, 0, 34642, 1, NULL_ADDRESS);
+    let responseThree = createUnsignedInterestResponse(nodeThree, 0, 34632, 1, NULL_ADDRESS);
+    let responseFour = createUnsignedInterestResponse(nodeFour, 0, 34620, 1, NULL_ADDRESS);
+    let responseFive = createUnsignedInterestResponse(nodeFive, 0, 34636, 1, NULL_ADDRESS);
+    let responseSix = createUnsignedInterestResponse(nodeSix, 0, 34636, 1, NULL_ADDRESS);
+    let responseSeven = createUnsignedInterestResponse(nodeSeven, 0, 34636, 1, NULL_ADDRESS);
+    let responseEight = createUnsignedInterestResponse(nodeEight, 0, 34636, 1, NULL_ADDRESS);
+    let responseNine = createUnsignedInterestResponse(nodeNine, 0, 34636, 1, NULL_ADDRESS);
 
-    before('Setup the response times and signatures', async () => {
-        currentTime = await getLatestTimestamp()
+    before("Setup the response times and signatures", async () => {
+        currentTime = await getLatestTimestamp();
 
         const consensusAddress = accounts[8];
         const chainId = chains.mainnet;
         lenders = await Mock.new();
 
-        interestRequest = createInterestRequest(lender, 1, 23456, endTime, 45678, consensusAddress)
-        const requestHash = ethUtil.bufferToHex(hashInterestRequest(interestRequest, lenders.address, chainId))
+        interestRequest = createInterestRequest(lender, 1, 23456, endTime, 45678, consensusAddress);
+        const requestHash = ethUtil.bufferToHex(hashInterestRequest(interestRequest, lenders.address, chainId));
 
-        responseOne.responseTime = currentTime - (2 * ONE_DAY)
-        responseTwo.responseTime = currentTime - (25 * ONE_DAY)
-        responseThree.responseTime = currentTime - (29 * ONE_DAY)
-        responseFour.responseTime = currentTime - ONE_DAY
-        responseFive.responseTime = currentTime - (15 * ONE_DAY)
-        responseSix.responseTime = currentTime - (21 * ONE_DAY)
-        responseSeven.responseTime = currentTime - (20 * ONE_DAY)
-        responseEight.responseTime = currentTime - (24 * ONE_DAY)
-        responseNine.responseTime = currentTime - (26 * ONE_DAY)
+        responseOne.responseTime = currentTime - 2 * ONE_DAY;
+        responseTwo.responseTime = currentTime - 25 * ONE_DAY;
+        responseThree.responseTime = currentTime - 29 * ONE_DAY;
+        responseFour.responseTime = currentTime - ONE_DAY;
+        responseFive.responseTime = currentTime - 15 * ONE_DAY;
+        responseSix.responseTime = currentTime - 21 * ONE_DAY;
+        responseSeven.responseTime = currentTime - 20 * ONE_DAY;
+        responseEight.responseTime = currentTime - 24 * ONE_DAY;
+        responseNine.responseTime = currentTime - 26 * ONE_DAY;
 
         responseOne.consensusAddress = consensusAddress;
         responseTwo.consensusAddress = consensusAddress;
@@ -82,79 +76,86 @@ contract('EstimateGasInterestConsensusProcessRequestTest', function (accounts) {
         responseEight.consensusAddress = consensusAddress;
         responseNine.consensusAddress = consensusAddress;
 
-        responseOne = await createInterestResponseSig(web3, nodeOne, responseOne, requestHash, chainId)
-        responseTwo = await createInterestResponseSig(web3, nodeTwo, responseTwo, requestHash, chainId)
-        responseThree = await createInterestResponseSig(web3, nodeThree, responseThree, requestHash, chainId)
-        responseFour = await createInterestResponseSig(web3, nodeFour, responseFour, requestHash, chainId)
-        responseFive = await createInterestResponseSig(web3, nodeFive, responseFive, requestHash, chainId)
-        responseSix = await createInterestResponseSig(web3, nodeSix, responseSix, requestHash, chainId)
-        responseSeven = await createInterestResponseSig(web3, nodeSeven, responseSeven, requestHash, chainId)
-        responseEight = await createInterestResponseSig(web3, nodeEight, responseEight, requestHash, chainId)
-        responseNine = await createInterestResponseSig(web3, nodeNine, responseNine, requestHash, chainId)
-    })
+        responseOne = await createInterestResponseSig(web3, nodeOne, responseOne, requestHash, chainId);
+        responseTwo = await createInterestResponseSig(web3, nodeTwo, responseTwo, requestHash, chainId);
+        responseThree = await createInterestResponseSig(web3, nodeThree, responseThree, requestHash, chainId);
+        responseFour = await createInterestResponseSig(web3, nodeFour, responseFour, requestHash, chainId);
+        responseFive = await createInterestResponseSig(web3, nodeFive, responseFive, requestHash, chainId);
+        responseSix = await createInterestResponseSig(web3, nodeSix, responseSix, requestHash, chainId);
+        responseSeven = await createInterestResponseSig(web3, nodeSeven, responseSeven, requestHash, chainId);
+        responseEight = await createInterestResponseSig(web3, nodeEight, responseEight, requestHash, chainId);
+        responseNine = await createInterestResponseSig(web3, nodeNine, responseNine, requestHash, chainId);
+    });
 
-    withData({
-        _1_response: [
-            320, [responseOne]
-        ],
-        _2_responses: [ 
-            320, [responseOne, responseTwo]
-        ],
-        _3_responses: [
-            120, [responseOne, responseTwo, responseThree]
-        ],
-        _4_responses: [
-            90, [responseOne, responseTwo, responseThree, responseFour]
-        ],
-        _5_responses: [
-            150, [responseOne, responseTwo, responseThree, responseFour, responseFive]
-        ],
-        _6_responses: [
-            190, [responseOne, responseTwo, responseThree, responseFour, responseFive, responseSix]
-        ],
-        _7_responses: [
-            110, [responseOne, responseTwo, responseThree, responseFour, responseFive, responseSix, responseSeven]
-        ],
-        _8_responses: [
-            180, [responseOne, responseTwo, responseThree, responseFour, responseFive, responseSix, responseSeven, responseEight]
-        ],
-        _9_responses: [
-            220, [responseOne, responseTwo, responseThree, responseFour, responseFive, responseSix, responseSeven, responseEight, responseNine]
-        ],
-    }, function(
-        tolerance,
-        responses,
-    ) {    
-        it(t('user', 'new', 'Should accept/not accept a nodes response', false), async function() {
-            // set up contract
-            const expectedMaxGas = expectedGasCost(responses.length);
-            const settings = await createTestSettingsInstance(
-                Settings,
-                { from: owner, Mock },
-                {
-                    [settingsNames.RequiredSubmissions]: responses.length,
-                    [settingsNames.MaximumTolerance]: tolerance,
-                    [settingsNames.ResponseExpiryLength]: THIRTY_DAYS,
-                    [settingsNames.TermsExpiryTime]: THIRTY_DAYS,
-                    [settingsNames.LiquidateEthPrice]: 9500,
+    withData(
+        {
+            _1_response: [320, [responseOne]],
+            _2_responses: [320, [responseOne, responseTwo]],
+            _3_responses: [120, [responseOne, responseTwo, responseThree]],
+            _4_responses: [90, [responseOne, responseTwo, responseThree, responseFour]],
+            _5_responses: [150, [responseOne, responseTwo, responseThree, responseFour, responseFive]],
+            _6_responses: [190, [responseOne, responseTwo, responseThree, responseFour, responseFive, responseSix]],
+            _7_responses: [
+                110,
+                [responseOne, responseTwo, responseThree, responseFour, responseFive, responseSix, responseSeven],
+            ],
+            _8_responses: [
+                180,
+                [
+                    responseOne,
+                    responseTwo,
+                    responseThree,
+                    responseFour,
+                    responseFive,
+                    responseSix,
+                    responseSeven,
+                    responseEight,
+                ],
+            ],
+            _9_responses: [
+                220,
+                [
+                    responseOne,
+                    responseTwo,
+                    responseThree,
+                    responseFour,
+                    responseFive,
+                    responseSix,
+                    responseSeven,
+                    responseEight,
+                    responseNine,
+                ],
+            ],
+        },
+        function (tolerance, responses) {
+            it(t("user", "new", "Should accept/not accept a nodes response", false), async function () {
+                // set up contract
+                const expectedMaxGas = expectedGasCost(responses.length);
+                const settings = await createTestSettingsInstance(
+                    Settings,
+                    {from: owner, Mock},
+                    {
+                        [settingsNames.RequiredSubmissionsPercentage]: 10000,
+                        [settingsNames.MaximumTolerance]: tolerance,
+                        [settingsNames.ResponseExpiryLength]: THIRTY_DAYS,
+                        [settingsNames.TermsExpiryTime]: THIRTY_DAYS,
+                        [settingsNames.LiquidateEthPrice]: 9500,
+                    }
+                );
+                // The sender validation (equal to the lenders contract) is mocked (InterestConsensusMock _isCaller(...) function) to allow execute the unit test.
+                const sender = accounts[1];
+                instance = await InterestConsensus.new();
+                await instance.initialize(owner, lenders.address, settings.address);
+
+                for (const response of responses) {
+                    await instance.addSigner(response.signer);
                 }
-            );
-            // The sender validation (equal to the lenders contract) is mocked (InterestConsensusMock _isCaller(...) function) to allow execute the unit test.
-            const sender = accounts[1];
-            instance = await InterestConsensus.new();
-            await instance.initialize(owner, lenders.address, settings.address);
 
-            for (const response of responses) {
-                await instance.addSigner(response.signer)
-            }
-
-            const result = await instance.processRequest.estimateGas(
-                interestRequest,
-                responses, {
-                    from: sender
-                }
-            );
-            assert(parseInt(result) <= expectedMaxGas, 'Expected max gas less than result.');
-        })
-    })
-})
+                const result = await instance.processRequest.estimateGas(interestRequest, responses, {
+                    from: sender,
+                });
+                assert(parseInt(result) <= expectedMaxGas, "Expected max gas less than result.");
+            });
+        }
+    );
+});

--- a/test/base/EstimateGasLoanTermsConsensusProcessRequestTest.js
+++ b/test/base/EstimateGasLoanTermsConsensusProcessRequestTest.js
@@ -136,7 +136,7 @@ contract('EstimateGasLoanTermsConsensusProcessRequestTest', function (accounts) 
                 Settings,
                 { from: owner, Mock },
                 {
-                    [settingsNames.RequiredSubmissions]: responses.length,
+                    [settingsNames.RequiredSubmissionsPercentage]: 10000,
                     [settingsNames.MaximumTolerance]: tolerance,
                     [settingsNames.ResponseExpiryLength]: THIRTY_DAYS,
                     [settingsNames.TermsExpiryTime]: THIRTY_DAYS,

--- a/test/base/InterestConsensusProcessRequestTest.js
+++ b/test/base/InterestConsensusProcessRequestTest.js
@@ -84,35 +84,35 @@ contract('InterestConsensusProcessRequestTest', function (accounts) {
 
     withData({
         _1_insufficient_responses: [
-            undefined, 3, 320, [responseOne, responseTwo], true, 'INTEREST_INSUFFICIENT_RESPONSES'
+            undefined, 10000, 320, [responseOne, responseTwo], true, 'INSUFFICIENT_NUMBER_OF_RESPONSES'
         ],
         _2_one_response_successful: [
-            undefined, 1, 320, [responseOne], false, undefined
+            undefined, 1000, 320, [responseOne], false, undefined
         ],
         _3_responses_just_over_tolerance: [  // average = 34860, tolerance = 1115, max is 35976 (1 too much)
-            undefined, 4, 320, [responseOne, responseTwo, responseThree, responseFour], true, 'RESPONSES_TOO_VARIED'
+            undefined, 1000, 320, [responseOne, responseTwo, responseThree, responseFour], true, 'RESPONSES_TOO_VARIED'
         ],
         _4_responses_just_within_tolerance: [  // average = 34861, tolerance = 1115, max is 35976 (perfect)
-            undefined, 4, 320, [responseOne, responseTwo, responseFour, responseFive], false, undefined
+            undefined, 1000, 320, [responseOne, responseTwo, responseFour, responseFive], false, undefined
         ],
         _5_zero_tolerance: [
-            undefined, 1, 0, [responseTwo, responseThree], false, undefined
+            undefined, 1000, 0, [responseTwo, responseThree], false, undefined
         ],
         _6_two_responses_same_signer: [     // responseThree and five have the same signer
-            undefined, 4, 320, [responseOne, responseThree, responseTwo, responseFive], true, 'SIGNER_ALREADY_SUBMITTED'
+            undefined, 1000, 320, [responseOne, responseThree, responseTwo, responseFive], true, 'SIGNER_ALREADY_SUBMITTED'
         ],
         _7_expired_response: [
-            undefined, 4, 320, [responseOne, responseTwo, responseExpired, responseFive], true, 'RESPONSE_EXPIRED'
+            undefined, 1000, 320, [responseOne, responseTwo, responseExpired, responseFive], true, 'RESPONSE_EXPIRED'
         ],
         _8_responses_invalid_response_chainid: [
-            undefined, 4, 320, [responseOne, responseTwo, responseFour, responseInvalidChainId], true, 'SIGNATURE_INVALID'
+            undefined, 1000, 320, [responseOne, responseTwo, responseFour, responseInvalidChainId], true, 'SIGNATURE_INVALID'
         ],
         _9_responses_invalid_request_nonce_taken: [
-            { nonce: requestNonce, lender: lender }, 3, 320, [responseOne, responseTwo, responseFour], true, 'INTEREST_REQUEST_NONCE_TAKEN'
+            { nonce: requestNonce, lender: lender }, 1000, 320, [responseOne, responseTwo, responseFour], true, 'INTEREST_REQUEST_NONCE_TAKEN'
         ],
     }, function(
         requestNonceTaken,
-        reqSubmissions,
+        reqSubmissionsPercentage,
         tolerance,
         responses,
         mustFail,
@@ -125,14 +125,13 @@ contract('InterestConsensusProcessRequestTest', function (accounts) {
                 Settings,
                 { from: owner, Mock },
                 {
-                    [settingsNames.RequiredSubmissions]: reqSubmissions,
+                    [settingsNames.RequiredSubmissionsPercentage]: reqSubmissionsPercentage,
                     [settingsNames.MaximumTolerance]: tolerance,
                     [settingsNames.ResponseExpiryLength]: THIRTY_DAYS,
                     [settingsNames.TermsExpiryTime]: THIRTY_DAYS,
                     [settingsNames.LiquidateEthPrice]: 9500,
                 }
             );
-
             // The sender validation (equal to the lenders contract) is mocked (InterestConsensusMock _isCaller(...) function) to allow execute the unit test.
             const sender = accounts[1];
             await instance.initialize(owner,lenders.address, settings.address);

--- a/test/base/InterestConsensusProcessResponseTest.js
+++ b/test/base/InterestConsensusProcessResponseTest.js
@@ -26,7 +26,6 @@ contract('InterestConsensusProcessResponseTest', function (accounts) {
     let instance;
     const lendersContract = accounts[1]
     const nodeAddress = accounts[2]
-    const submissions = 5
     const tolerance = 0
     const endTime = 34567
     const lender = accounts[3]
@@ -75,7 +74,7 @@ contract('InterestConsensusProcessResponseTest', function (accounts) {
                 Settings,
                 { from: owner, Mock },
                 {
-                    [settingsNames.RequiredSubmissions]: submissions,
+                    [settingsNames.RequiredSubmissionsPercentage]: 10000,
                     [settingsNames.MaximumTolerance]: tolerance,
                     [settingsNames.ResponseExpiryLength]: THIRTY_DAYS,
                     [settingsNames.TermsExpiryTime]: THIRTY_DAYS,

--- a/test/base/LoanTermsConsensusProcessRequestTest.js
+++ b/test/base/LoanTermsConsensusProcessRequestTest.js
@@ -85,37 +85,37 @@ contract('LoanTermsConsensusProcessRequestTest', function (accounts) {
 
     withData({
         _1_insufficient_responses: [
-            3, 320, undefined, undefined, [responseOne, responseTwo], true, 'LOANTERM_INSUFFICIENT_RESPONSES'
+            10000, 320, undefined, undefined, [responseOne, responseTwo], true, 'INSUFFICIENT_NUMBER_OF_RESPONSES'
         ],
         _2_one_response_successful: [
-            1, 320, undefined, undefined, [responseOne], false, undefined
+            2000, 320, undefined, undefined, [responseOne], false, undefined
         ],
         _3_responses_just_over_tolerance: [  
-            4, 310, undefined, undefined, [responseOne, responseTwo, responseThree, responseFour], true, 'RESPONSES_TOO_VARIED'
+            8000, 310, undefined, undefined, [responseOne, responseTwo, responseThree, responseFour], true, 'RESPONSES_TOO_VARIED'
         ],
         _4_responses_just_within_tolerance: [
-            4, 320, undefined, undefined, [responseOne, responseTwo, responseFour, responseFive], false, undefined
+            8000, 320, undefined, undefined, [responseOne, responseTwo, responseFour, responseFive], false, undefined
         ],
         _5_zero_tolerance: [
-            1, 0, undefined, undefined, [responseTwo, responseThree], false, undefined
+            4000, 0, undefined, undefined, [responseTwo, responseThree], false, undefined
         ],
         _6_two_responses_same_signer: [     // responseThree and five have the same signer
-            4, 320, undefined, undefined, [responseOne, responseThree, responseTwo, responseFive], true, 'SIGNER_ALREADY_SUBMITTED'
+            8000, 320, undefined, undefined, [responseOne, responseThree, responseTwo, responseFive], true, 'SIGNER_ALREADY_SUBMITTED'
         ],
         _7_expired_response: [
-            4, 320, undefined, undefined, [responseOne, responseTwo, responseFour, responseExpired], true, 'RESPONSE_EXPIRED'
+            8000, 320, undefined, undefined, [responseOne, responseTwo, responseFour, responseExpired], true, 'RESPONSE_EXPIRED'
         ],
         _8_signer_nonce_taken: [
-            3, 320, { nonce: 0, signer: nodeOne }, undefined, [responseFive, responseOne, responseTwo], true, 'SIGNER_NONCE_TAKEN'
+            6000, 320, { nonce: 0, signer: nodeOne }, undefined, [responseFive, responseOne, responseTwo], true, 'SIGNER_NONCE_TAKEN'
         ],
         _9_responses_invalid_sig_chainid: [
-            4, 320, undefined, undefined, [responseOne, responseTwo, responseFour, responseInvalidChainId], true, 'SIGNATURE_INVALID'
+            8000, 320, undefined, undefined, [responseOne, responseTwo, responseFour, responseInvalidChainId], true, 'SIGNATURE_INVALID'
         ],
         _10_borrower_nonce_taken: [
-            3, 360, undefined, { nonce: requestNonce, borrower: borrower }, [responseFive, responseOne, responseTwo], true, 'LOAN_TERMS_REQUEST_NONCE_TAKEN'
+            6000, 360, undefined, { nonce: requestNonce, borrower: borrower }, [responseFive, responseOne, responseTwo], true, 'LOAN_TERMS_REQUEST_NONCE_TAKEN'
         ],
     }, function(
-        reqSubmissions,
+        reqSubmissionsPercentage,
         tolerance,
         signerNonceTaken,
         requestNonceTaken,
@@ -129,7 +129,7 @@ contract('LoanTermsConsensusProcessRequestTest', function (accounts) {
                 Settings,
                 { from: owner, Mock },
                 {
-                    [settingsNames.RequiredSubmissions]: reqSubmissions,
+                    [settingsNames.RequiredSubmissionsPercentage]: reqSubmissionsPercentage,
                     [settingsNames.MaximumTolerance]: tolerance,
                     [settingsNames.ResponseExpiryLength]: THIRTY_DAYS,
                     [settingsNames.TermsExpiryTime]: THIRTY_DAYS,

--- a/test/base/LoanTermsConsensusProcessResponseTest.js
+++ b/test/base/LoanTermsConsensusProcessResponseTest.js
@@ -28,7 +28,6 @@ contract('LoanTermsConsensusProcessResponseTest', function (accounts) {
     let settings
     const loansContract = accounts[1]
     const nodeAddress = accounts[2]
-    const requiredSubs = 5
     const tolerance = 0
     const borrower = accounts[3]
     const requestNonce = 142
@@ -93,7 +92,7 @@ contract('LoanTermsConsensusProcessResponseTest', function (accounts) {
                 Settings,
                 { from: owner, Mock },
                 {
-                    [settingsNames.RequiredSubmissions]: requiredSubs,
+                    [settingsNames.RequiredSubmissionsPercentage]: 2000,
                     [settingsNames.MaximumTolerance]: tolerance,
                     [settingsNames.ResponseExpiryLength]: THIRTY_DAYS,
                     [settingsNames.TermsExpiryTime]: THIRTY_DAYS,

--- a/test/base/SettingsGetAndHasPlatformSettingTest.js
+++ b/test/base/SettingsGetAndHasPlatformSettingTest.js
@@ -27,7 +27,7 @@ contract('SettingsGetAndHasPlatformSettingTest', function (accounts) {
         _1_maximumLoanDuration: [settingsNames.MaximumLoanDuration, newSetting(1000, 0, 1001)],
         _2_safetyInterval: [settingsNames.SafetyInterval, newSetting(1000, 200, 2000)],
         _3_maximumTolerance: [settingsNames.MaximumTolerance, newSetting(1200, 100, 2000)],
-        _4_requiredSubmissions: [settingsNames.RequiredSubmissions, newSetting(400, 0, 4500)],
+        _4_requiredSubmissionsPercentage: [settingsNames.RequiredSubmissionsPercentage, newSetting(8000, 0, 10000)],
         _5_responseExpiryLength: [settingsNames.ResponseExpiryLength, newSetting(735, 0, 9000)],
         _6_termsExpiryTime: [settingsNames.TermsExpiryTime, newSetting(2225, 0, 20000)],
         _7_liquidateEthPrice: [settingsNames.LiquidateEthPrice, newSetting(9325, 9324, 10000)],
@@ -57,7 +57,7 @@ contract('SettingsGetAndHasPlatformSettingTest', function (accounts) {
 
     withData({
         _1_has: [settingsNames.MaximumLoanDuration, newSetting(1000, 0, 1001), settingsNames.MaximumLoanDuration, true],
-        _2_hasnt: [settingsNames.MaximumTolerance, newSetting(1000, 0, 1001), settingsNames.RequiredSubmissions, false],
+        _2_hasnt: [settingsNames.MaximumTolerance, newSetting(1000, 0, 1001), settingsNames.RequiredSubmissionsPercentage, false],
     }, function(settingKey, currentValue, settingNameToTest, expectedResult) {
         it(t('user', `hasPlatformSetting`, `Should be able to get the current platform setting (${settingKey}) value.`, false), async function() {
             // Setup

--- a/test/utils/consts.js
+++ b/test/utils/consts.js
@@ -1,117 +1,127 @@
-const { BigNumber } = require( 'bignumber.js');
+const {BigNumber} = require("bignumber.js");
 
-const REQUIRED_SUBMISSIONS = 'RequiredSubmissions';
-const MAXIMUM_TOLERANCE = 'MaximumTolerance';
-const RESPONSE_EXPIRY_LENGTH = 'ResponseExpiryLength';
-const SAFETY_INTERVAL = 'SafetyInterval';
-const TERMS_EXPIRY_TIME = 'TermsExpiryTime';
-const LIQUIDATE_ETH_PRICE = 'LiquidateEthPrice';
+const REQUIRED_SUBMISSIONS_PERCENTAGE = "RequiredSubmissionsPercentage";
+const MAXIMUM_TOLERANCE = "MaximumTolerance";
+const RESPONSE_EXPIRY_LENGTH = "ResponseExpiryLength";
+const SAFETY_INTERVAL = "SafetyInterval";
+const TERMS_EXPIRY_TIME = "TermsExpiryTime";
+const LIQUIDATE_ETH_PRICE = "LiquidateEthPrice";
 const DEFAULT_DECIMALS = 18;
-const ETH_ADDRESS = '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE';
-const WETH_ADDRESS = '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2';
-const NULL_ADDRESS = '0x0000000000000000000000000000000000000000';
-const DUMMY_ADDRESS = '0x0000000000000000000000000000000000000123';
-const NULL_BYTES = '0x0000000000000000000000000000000000000000000000000000000000000000'
+const ETH_ADDRESS = "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE";
+const WETH_ADDRESS = "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2";
+const NULL_ADDRESS = "0x0000000000000000000000000000000000000000";
+const DUMMY_ADDRESS = "0x0000000000000000000000000000000000000123";
+const NULL_BYTES =
+  "0x0000000000000000000000000000000000000000000000000000000000000000";
 const ZERO = new BigNumber(0);
-const NETWORK_PROVIDER = 'http://127.0.0.1:7545';
-const COVERAGE_NETWORK = 'http://127.0.0.1:8555';
-const FIVE_MIN = 60*5
-const ONE_HOUR = 3600 // 60 seconds * 60 minutes = 1 hour
-const ONE_DAY = ONE_HOUR*24
-const ONE_YEAR = ONE_DAY*365
-const THIRTY_DAYS = ONE_DAY*30
-const NON_EXISTENT = 0
-const TERMS_SET = 1
-const ACTIVE = 2
-const CLOSED = 3
+const NETWORK_PROVIDER = "http://127.0.0.1:7545";
+const COVERAGE_NETWORK = "http://127.0.0.1:8555";
+const FIVE_MIN = 60 * 5;
+const ONE_HOUR = 3600; // 60 seconds * 60 minutes = 1 hour
+const ONE_DAY = ONE_HOUR * 24;
+const ONE_YEAR = ONE_DAY * 365;
+const THIRTY_DAYS = ONE_DAY * 30;
+const NON_EXISTENT = 0;
+const TERMS_SET = 1;
+const ACTIVE = 2;
+const CLOSED = 3;
 
 const toDecimals = (amount, decimals) => {
-    return new BigNumber(amount).times(new BigNumber(10).pow(decimals));
-}
+  return new BigNumber(amount).times(new BigNumber(10).pow(decimals));
+};
 
 module.exports = {
-    CTOKEN_DECIMALS: 8,
-    ETH_ADDRESS,
-    DUMMY_ADDRESS,
-    NON_EXISTENT,
-    TERMS_SET,
-    ACTIVE,
-    CLOSED,
-    DEFAULT_DECIMALS,
-    NULL_ADDRESS,
-    NULL_BYTES,
-    ZERO,
-    NETWORK_PROVIDER,
-    COVERAGE_NETWORK,
-    FIVE_MIN,
-    ONE_HOUR,
-    ONE_DAY,
-    ONE_YEAR,
-    THIRTY_DAYS,
-    REQUIRED_SUBMISSIONS,
-    MAXIMUM_TOLERANCE,
-    RESPONSE_EXPIRY_LENGTH,
-    SAFETY_INTERVAL,
-    TERMS_EXPIRY_TIME,
-    LIQUIDATE_ETH_PRICE,
-    // For interestRate, collateral, and liquidation price, 7% is represented as 700. To find the value
-    // of something we must divide 700 by 100 to remove decimal places, and another 100 for percentage.
-    TEN_THOUSAND: 10000,
-    t: function (who, func, desc, fail) {
-        const failText = fail ? '\x1b[31mMustFail\x1b[0m .' : '\x1b[0m';
-        return '\x1b[32m.' + func + ' => \x1b[36m' + who + '\x1b[0m\x1b[01;34m : ' + desc + ' '+ failText;
-    },
-    encode: (web3, signature) => {
-        return web3.utils.sha3(signature).slice(0,10);
-    },
-    getMillis: (year, month, day) => {
-        return new Date(year, month, day).getTime();
-    },
-    daysToMillis: (days) => {
-        return parseInt(days.toString()) * 24 * 60 * 60 * 1000;
-    },
-    daysToSeconds: (days) => {
-        return parseInt(days.toString()) * 24 * 60 * 60;
-    },
-    daysToMinutes: (days) => {
-        return parseInt(days.toString()) * 24 * 60;
-    },
-    secondsToDays: (seconds) => {
-        return parseInt(seconds.toString()) / (24 * 60 * 60);
-    },
-    millisToDays: (millis) => {
-        return parseInt(millis.toString()) / (24 * 60 * 60 * 1000);
-    },
-    minutesToSeconds: (minutes) => {
-        return parseInt(minutes.toString()) * 60;
-    },
-    daysToSeconds: (days) => {
-        return parseInt(days.toString()) * 24 * 60 * 60;
-    },
-    getLatestTimestamp: async () => {
-      return (await web3.eth.getBlock('latest')).timestamp
-    },
-    sum: (a, b) => parseInt(a.toString()) + parseInt(b.toString()),
-    toBytes32: (web3, text) => {
-      return web3.utils.padRight(web3.utils.stringToHex(text), 64, '0');
-    },
-    toDecimals,
-    toTokenDecimals: async (token, amount) => {
-        const decimals = await token.decimals();
-        return toDecimals(amount, decimals);
-    },
-    toUnits: (amount, decimals) => {
-        return new BigNumber(amount).div(new BigNumber(10).pow(decimals));
-    },
-    printSeparatorLine: (length = 100, separator = '-') => {
-        console.log(`\n${separator.repeat(length)}\n`);
-    },
-    createMocks: async (Mock, total) => {
-        const result = [];
-        for (const index of _.range(0, total)) {
-            const mock = await Mock.new();
-            result.push(mock.address);
-        }
-        return result;
-    },
-}
+  CTOKEN_DECIMALS: 8,
+  ETH_ADDRESS,
+  DUMMY_ADDRESS,
+  NON_EXISTENT,
+  TERMS_SET,
+  ACTIVE,
+  CLOSED,
+  DEFAULT_DECIMALS,
+  NULL_ADDRESS,
+  NULL_BYTES,
+  ZERO,
+  NETWORK_PROVIDER,
+  COVERAGE_NETWORK,
+  FIVE_MIN,
+  ONE_HOUR,
+  ONE_DAY,
+  ONE_YEAR,
+  THIRTY_DAYS,
+  REQUIRED_SUBMISSIONS_PERCENTAGE,
+  MAXIMUM_TOLERANCE,
+  RESPONSE_EXPIRY_LENGTH,
+  SAFETY_INTERVAL,
+  TERMS_EXPIRY_TIME,
+  LIQUIDATE_ETH_PRICE,
+  // For interestRate, collateral, and liquidation price, 7% is represented as 700. To find the value
+  // of something we must divide 700 by 100 to remove decimal places, and another 100 for percentage.
+  TEN_THOUSAND: 10000,
+  t: function (who, func, desc, fail) {
+    const failText = fail ? "\x1b[31mMustFail\x1b[0m ." : "\x1b[0m";
+    return (
+      "\x1b[32m." +
+      func +
+      " => \x1b[36m" +
+      who +
+      "\x1b[0m\x1b[01;34m : " +
+      desc +
+      " " +
+      failText
+    );
+  },
+  encode: (web3, signature) => {
+    return web3.utils.sha3(signature).slice(0, 10);
+  },
+  getMillis: (year, month, day) => {
+    return new Date(year, month, day).getTime();
+  },
+  daysToMillis: (days) => {
+    return parseInt(days.toString()) * 24 * 60 * 60 * 1000;
+  },
+  daysToSeconds: (days) => {
+    return parseInt(days.toString()) * 24 * 60 * 60;
+  },
+  daysToMinutes: (days) => {
+    return parseInt(days.toString()) * 24 * 60;
+  },
+  secondsToDays: (seconds) => {
+    return parseInt(seconds.toString()) / (24 * 60 * 60);
+  },
+  millisToDays: (millis) => {
+    return parseInt(millis.toString()) / (24 * 60 * 60 * 1000);
+  },
+  minutesToSeconds: (minutes) => {
+    return parseInt(minutes.toString()) * 60;
+  },
+  daysToSeconds: (days) => {
+    return parseInt(days.toString()) * 24 * 60 * 60;
+  },
+  getLatestTimestamp: async () => {
+    return (await web3.eth.getBlock("latest")).timestamp;
+  },
+  sum: (a, b) => parseInt(a.toString()) + parseInt(b.toString()),
+  toBytes32: (web3, text) => {
+    return web3.utils.padRight(web3.utils.stringToHex(text), 64, "0");
+  },
+  toDecimals,
+  toTokenDecimals: async (token, amount) => {
+    const decimals = await token.decimals();
+    return toDecimals(amount, decimals);
+  },
+  toUnits: (amount, decimals) => {
+    return new BigNumber(amount).div(new BigNumber(10).pow(decimals));
+  },
+  printSeparatorLine: (length = 100, separator = "-") => {
+    console.log(`\n${separator.repeat(length)}\n`);
+  },
+  createMocks: async (Mock, total) => {
+    const result = [];
+    for (const index of _.range(0, total)) {
+      const mock = await Mock.new();
+      result.push(mock.address);
+    }
+    return result;
+  },
+};

--- a/test/utils/platformSettingsNames.js
+++ b/test/utils/platformSettingsNames.js
@@ -3,28 +3,27 @@
  */
 module.exports = {
     // The setting name for the required subsmission settings.
-    RequiredSubmissions: 'RequiredSubmissions',
+    RequiredSubmissionsPercentage: "RequiredSubmissionsPercentage",
     // The setting name for the maximum tolerance settings.
-    MaximumTolerance: 'MaximumTolerance',
+    MaximumTolerance: "MaximumTolerance",
     // The setting name for the response expiry length settings.
-    ResponseExpiryLength: 'ResponseExpiryLength',
+    ResponseExpiryLength: "ResponseExpiryLength",
     //The setting name for the safety interval settings.
-    SafetyInterval: 'SafetyInterval',
+    SafetyInterval: "SafetyInterval",
     // The setting name for the term expiry time settings.
     TermsExpiryTime: "TermsExpiryTime",
     // The setting name for the liquidate ETH price settings.
-    LiquidateEthPrice: 'LiquidateEthPrice',
+    LiquidateEthPrice: "LiquidateEthPrice",
     // The setting name for the maximum loan duration settings.
     MaximumLoanDuration: "MaximumLoanDuration",
     // The setting name for the collateral buffer settings.
-    CollateralBuffer: 'CollateralBuffer',
+    CollateralBuffer: "CollateralBuffer",
     // The setting name for the over collateralized buffer settings.
-    OverCollateralizedBuffer: 'OverCollateralizedBuffer',
+    OverCollateralizedBuffer: "OverCollateralizedBuffer",
     // The setting name for the starting block offset number settings.
-    StartingBlockOffsetNumber: 'StartingBlockOffsetNumber',
+    StartingBlockOffsetNumber: "StartingBlockOffsetNumber",
     // The setting name for the starting block number settings.
-    StartingBlockNumber: 'StartingBlockNumber',
+    StartingBlockNumber: "StartingBlockNumber",
     // The setting name for the request loan terms rate limit settings.
-    RequestLoanTermsRateLimit: 'RequestLoanTermsRateLimit',
-
-}
+    RequestLoanTermsRateLimit: "RequestLoanTermsRateLimit",
+};

--- a/test/utils/settings-helper.js
+++ b/test/utils/settings-helper.js
@@ -6,7 +6,7 @@ const initPlatformSettings = require('../../migrations/utils/init_settings/initP
 
 const INITIAL_VALUE = 1;
 const TEST_DEFAULT_VALUE = {
-    requiredSubmissions: INITIAL_VALUE,
+    requiredSubmissionsPercentage: INITIAL_VALUE,
     maximumTolerance: INITIAL_VALUE,
     responseExpiryLength: INITIAL_VALUE,
     safetyInterval: INITIAL_VALUE,


### PR DESCRIPTION
Fix adds a modifier to the Consensus contract requiring that the number of responses in the call is greater than or equal to number of singers - 1. Number of signers tracked when _addSigner and _removeSigner is called on OwnerSignersRole.