### PR TITLE
Include utils folder in ts-config.

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,20 @@
     "strict": true
   },
   "files": ["hardhat.config.ts"],
-  "include": ["./test", "./typechain", "./deploy", "./config", "./test-utils"],
-  "exclude": ["./contracts", "./build", "./artifacts", "./docs", "./cache", "./coverage"]
+  "include": [
+    "./test",
+    "./types",
+    "./deploy",
+    "./config",
+    "./test-utils",
+    "./utils"
+  ],
+  "exclude": [
+    "./contracts",
+    "./build",
+    "./artifacts",
+    "./docs",
+    "./cache",
+    "./coverage"
+  ]
 }


### PR DESCRIPTION
Importing the hardhat module now automatically knows `HardhatRuntimeEnvironment` extended types.