### PR TITLE
[PROTOCOL-449] [M03] Lack of event emission after sensitive actions

### DIFF
--- a/contracts/base/BaseEscrowDapp.sol
+++ b/contracts/base/BaseEscrowDapp.sol
@@ -74,7 +74,7 @@ contract BaseEscrowDapp is Ownable, BaseUpgradeable {
                 tokens.add(tokenAddress);
                 emit TokenAdded(tokenAddress, index);
             }
-        } else if (found) {            
+        } else if (found) {
             tokens.remove(index);
             emit TokenRemoved(tokenAddress, index);
         }

--- a/contracts/base/BaseEscrowDapp.sol
+++ b/contracts/base/BaseEscrowDapp.sol
@@ -14,6 +14,20 @@ contract BaseEscrowDapp is Ownable, BaseUpgradeable {
     using AddressArrayLib for address[];
 
     /**
+        @notice This event is emitted when a new token is added to this Escrow.
+        @param tokenAddress address of the new token.
+        @param index Index of the added token.
+     */
+    event TokenAdded(address tokenAddress, uint256 index);
+
+    /**
+        @notice This event is emitted when a new token is removed from this Escrow.
+        @param tokenAddress address of the removed token.
+        @param index Index of the removed token.
+     */
+    event TokenRemoved(address tokenAddress, uint256 index);
+
+    /**
         @notice An array of tokens that are owned by this escrow.
      */
     address[] private tokens;
@@ -31,7 +45,11 @@ contract BaseEscrowDapp is Ownable, BaseUpgradeable {
         @param tokenAddress The contract address for which the index is required.
         @return The index number of the token contract address, stored in the Escrow's array.
      */
-    function findTokenIndex(address tokenAddress) external view returns (int256) {
+    function findTokenIndex(address tokenAddress)
+        external
+        view
+        returns (int256)
+    {
         (bool found, uint256 index) = tokens.getIndex(tokenAddress);
         return found ? int256(index) : -1;
     }
@@ -54,9 +72,11 @@ contract BaseEscrowDapp is Ownable, BaseUpgradeable {
         if (_balanceOf(tokenAddress) > 0) {
             if (!found) {
                 tokens.add(tokenAddress);
+                emit TokenAdded(tokenAddress, index);
             }
         } else if (found) {
             tokens.removeAt(index);
+            emit TokenRemoved(tokenAddress, index);
         }
     }
 

--- a/contracts/base/Settings.sol
+++ b/contracts/base/Settings.sol
@@ -362,6 +362,7 @@ contract Settings is
         isInitialized()
     {
         platformRestricted = restriction;
+        emit PlatformRestriced(restriction, msg.sender);
     }
 
     /**
@@ -382,6 +383,7 @@ contract Settings is
             "CALLER_NOT_PAUSER"
         );
         authorizedAddresses[addressToAdd] = true;
+        emit AddressAuthorized(addressToAdd, msg.sender);
     }
 
     /**
@@ -395,6 +397,7 @@ contract Settings is
         for (uint256 i = 0; i < addressesToAdd.length; i++) {
             addAuthorizedAddress(addressesToAdd[i]);
         }
+        emit AddressesAuthorized(addressesToAdd.length, msg.sender);
     }
 
     /**
@@ -407,6 +410,7 @@ contract Settings is
         isInitialized()
     {
         authorizedAddresses[addressToRemove] = false;
+        emit AuthorizationRevoked(addressToRemove, msg.sender);
     }
 
     /**

--- a/contracts/base/Settings.sol
+++ b/contracts/base/Settings.sol
@@ -362,7 +362,7 @@ contract Settings is
         isInitialized()
     {
         platformRestricted = restriction;
-        emit PlatformRestriced(restriction, msg.sender);
+        emit PlatformRestricted(restriction, msg.sender);
     }
 
     /**
@@ -383,7 +383,7 @@ contract Settings is
             "CALLER_NOT_PAUSER"
         );
         authorizedAddresses[addressToAdd] = true;
-        emit AddressAuthorized(addressToAdd, msg.sender);
+        emit AuthorizationGranted(addressToAdd, msg.sender);
     }
 
     /**
@@ -397,7 +397,6 @@ contract Settings is
         for (uint256 i = 0; i < addressesToAdd.length; i++) {
             addAuthorizedAddress(addressesToAdd[i]);
         }
-        emit AddressesAuthorized(addressesToAdd.length, msg.sender);
     }
 
     /**

--- a/contracts/interfaces/SettingsInterface.sol
+++ b/contracts/interfaces/SettingsInterface.sol
@@ -75,6 +75,43 @@ interface SettingsInterface {
     );
 
     /**
+        @notice This event is emitted when the platform restriction is switched
+        @param restriction Boolean representing the state of the restriction
+        @param pauser address of the pauser flipping the switch
+    */
+    event PlatformRestriced(bool restriction, address indexed pauser);
+
+    /**
+        @notice This event is emitted when an address is given authorization
+        @param addressToAdd The address being authorized
+        @param pauser address of the pauser adding the address
+    */
+    event AddressAuthorized(
+        address indexed addressToAdd,
+        address indexed pauser
+    );
+
+    /**
+        @notice This event is emitted when an array of address is given authorization
+        @param numberOfAddressAdded The number of address authorized
+        @param pauser address of the pauser adding the addresses
+    */
+    event AddressesAuthorized(
+        uint256 numberOfAddressAdded,
+        address indexed pauser
+    );
+
+    /**
+        @notice This event is emitted when an address has authorization revoked
+        @param addressToRemove The address being revoked
+        @param pauser address of the pauser removing the address
+    */
+    event AuthorizationRevoked(
+        address indexed addressToRemove,
+        address indexed pauser
+    );
+
+    /**
         @notice It creates a new platform setting given a setting name, value, min and max values.
         @param settingName setting name to create.
         @param value the initial value for the given setting name.

--- a/contracts/interfaces/SettingsInterface.sol
+++ b/contracts/interfaces/SettingsInterface.sol
@@ -79,37 +79,21 @@ interface SettingsInterface {
         @param restriction Boolean representing the state of the restriction
         @param pauser address of the pauser flipping the switch
     */
-    event PlatformRestriced(bool restriction, address indexed pauser);
+    event PlatformRestricted(bool restriction, address indexed pauser);
 
     /**
         @notice This event is emitted when an address is given authorization
-        @param addressToAdd The address being authorized
+        @param user The address being authorized
         @param pauser address of the pauser adding the address
     */
-    event AddressAuthorized(
-        address indexed addressToAdd,
-        address indexed pauser
-    );
-
-    /**
-        @notice This event is emitted when an array of address is given authorization
-        @param numberOfAddressAdded The number of address authorized
-        @param pauser address of the pauser adding the addresses
-    */
-    event AddressesAuthorized(
-        uint256 numberOfAddressAdded,
-        address indexed pauser
-    );
+    event AuthorizationGranted(address indexed user, address indexed pauser);
 
     /**
         @notice This event is emitted when an address has authorization revoked
-        @param addressToRemove The address being revoked
+        @param user The address being revoked
         @param pauser address of the pauser removing the address
     */
-    event AuthorizationRevoked(
-        address indexed addressToRemove,
-        address indexed pauser
-    );
+    event AuthorizationRevoked(address indexed user, address indexed pauser);
 
     /**
         @notice It creates a new platform setting given a setting name, value, min and max values.


### PR DESCRIPTION
It is: 
- Adding of event emission after changes in BaseEscrowDapp and Settings contracts to facilitate tracking and notify off-chain clients following the contracts’ activity.