### PR TITLE
[PROTOCOL-442] [C01] Needed collateral for liquidation doubles when using an Escrow

### DIFF
--- a/contracts/util/LoanLib.sol
+++ b/contracts/util/LoanLib.sol
@@ -312,9 +312,7 @@ library LoanLib {
                 loan.loanTerms.collateralRatio
             );
         } else {
-            neededInLendingTokens = int256(
-                loan.principalOwed.add(loan.interestOwed)
-            );
+            neededInLendingTokens = int256(loan.principalOwed);
             uint256 bufferPercent =
                 settings.getPlatformSettingValue(
                     settings.consts().COLLATERAL_BUFFER_SETTING()
@@ -326,13 +324,13 @@ library LoanLib {
             if (loan.escrow != address(0)) {
                 escrowLoanValue = EscrowInterface(loan.escrow)
                     .calculateTotalValue();
-                neededInLendingTokens = neededInLendingTokens.sub(
-                    int256(escrowLoanValue)
+                neededInLendingTokens = neededInLendingTokens.add(
+                    neededInLendingTokens.sub(int256(escrowLoanValue))
                 );
             }
-            neededInLendingTokens = neededInLendingTokens.percent(
-                requiredRatio
-            );
+            neededInLendingTokens = neededInLendingTokens
+                .add(int256(loan.interestOwed))
+                .percent(requiredRatio);
         }
     }
 

--- a/contracts/util/LoanLib.sol
+++ b/contracts/util/LoanLib.sol
@@ -10,11 +10,13 @@ import "../util/AddressLib.sol";
 import "../interfaces/SettingsInterface.sol";
 import "../interfaces/EscrowInterface.sol";
 import "../interfaces/LoansInterface.sol";
+import "../providers/openzeppelin/SignedSafeMath.sol";
 
 // Contracts
 
 library LoanLib {
     using SafeMath for uint256;
+    using SignedSafeMath for int256;
     using NumbersLib for uint256;
     using NumbersLib for int256;
     using AddressLib for address payable;
@@ -58,9 +60,10 @@ library LoanLib {
             duration: request.duration
         });
 
-        uint256 termsExpiryTime = settings.getPlatformSettingValue(
-            settings.consts().TERMS_EXPIRY_TIME_SETTING()
-        );
+        uint256 termsExpiryTime =
+            settings.getPlatformSettingValue(
+                settings.consts().TERMS_EXPIRY_TIME_SETTING()
+            );
         loan.termsExpiry = now.add(termsExpiryTime);
     }
 
@@ -70,14 +73,14 @@ library LoanLib {
         @param settings The settings instance for the platform.
         @return bool indicating whether the loan with specified parameters can be deposited to an EOA.
      */
-    function canGoToEOA(TellerCommon.Loan storage loan, SettingsInterface settings)
-        public
-        view
-        returns (bool)
-    {
-        uint256 overCollateralizedBuffer = settings.getPlatformSettingValue(
-            settings.consts().OVER_COLLATERALIZED_BUFFER_SETTING()
-        );
+    function canGoToEOA(
+        TellerCommon.Loan storage loan,
+        SettingsInterface settings
+    ) public view returns (bool) {
+        uint256 overCollateralizedBuffer =
+            settings.getPlatformSettingValue(
+                settings.consts().OVER_COLLATERALIZED_BUFFER_SETTING()
+            );
         return loan.loanTerms.collateralRatio >= overCollateralizedBuffer;
     }
 
@@ -87,11 +90,10 @@ library LoanLib {
         @param settings The settings instance for the platform.
         @return bool value of it being secured or not.
     */
-    function isSecured(TellerCommon.Loan storage loan, SettingsInterface settings)
-        public
-        view
-        returns (bool)
-    {
+    function isSecured(
+        TellerCommon.Loan storage loan,
+        SettingsInterface settings
+    ) public view returns (bool) {
         return
             loan.loanTerms.collateralRatio >=
             settings.getPlatformSettingValue(
@@ -104,7 +106,11 @@ library LoanLib {
         @param loan The loan for which to check the status
         @return bool value indicating if the loan is active or has terms set
      */
-    function isActiveOrSet(TellerCommon.Loan storage loan) public view returns (bool) {
+    function isActiveOrSet(TellerCommon.Loan storage loan)
+        public
+        view
+        returns (bool)
+    {
         return
             loan.status == TellerCommon.LoanStatus.Active ||
             loan.status == TellerCommon.LoanStatus.TermsSet;
@@ -114,9 +120,14 @@ library LoanLib {
         @notice Returns the total amount owed for a specified loan.
         @param loan The loan to get the total amount owed.
      */
-    function getTotalOwed(TellerCommon.Loan storage loan) public view returns (uint256) {
+    function getTotalOwed(TellerCommon.Loan storage loan)
+        public
+        view
+        returns (uint256)
+    {
         if (loan.status == TellerCommon.LoanStatus.TermsSet) {
-            uint256 interestOwed = getInterestOwedFor(loan, loan.loanTerms.maxLoanAmount);
+            uint256 interestOwed =
+                getInterestOwedFor(loan, loan.loanTerms.maxLoanAmount);
             return loan.loanTerms.maxLoanAmount.add(interestOwed);
         } else if (loan.status == TellerCommon.LoanStatus.Active) {
             return loan.principalOwed.add(loan.interestOwed);
@@ -128,7 +139,11 @@ library LoanLib {
         @notice Returns the total amount owed for a specified loan.
         @param loan The loan to get the total amount owed.
      */
-    function getLoanAmount(TellerCommon.Loan storage loan) public view returns (uint256) {
+    function getLoanAmount(TellerCommon.Loan storage loan)
+        public
+        view
+        returns (uint256)
+    {
         if (loan.status == TellerCommon.LoanStatus.TermsSet) {
             return loan.loanTerms.maxLoanAmount;
         } else if (loan.status == TellerCommon.LoanStatus.Active) {
@@ -142,11 +157,10 @@ library LoanLib {
         @param loan The loan to get the owed interest.
         @param amountBorrow The principal of the loan to take out.
      */
-    function getInterestOwedFor(TellerCommon.Loan storage loan, uint256 amountBorrow)
-        public
-        view
-        returns (uint256)
-    {
+    function getInterestOwedFor(
+        TellerCommon.Loan storage loan,
+        uint256 amountBorrow
+    ) public view returns (uint256) {
         return amountBorrow.percent(getInterestRatio(loan));
     }
 
@@ -184,11 +198,15 @@ library LoanLib {
         return
             TellerCommon.LoanCollateralInfo({
                 collateral: loan.collateral,
-                valueInLendingTokens: getCollateralInLendingTokens(loan, loansContract),
+                valueInLendingTokens: getCollateralInLendingTokens(
+                    loan,
+                    loansContract
+                ),
                 escrowLoanValue: escrowLoanValue,
                 neededInLendingTokens: neededInLending,
                 neededInCollateralTokens: neededInCollateral,
-                moreCollateralRequired: neededInCollateral > int256(loan.collateral)
+                moreCollateralRequired: neededInCollateral >
+                    int256(loan.collateral)
             });
     }
 
@@ -242,15 +260,16 @@ library LoanLib {
         if (neededInLendingTokens == 0) {
             neededInCollateralTokens = 0;
         } else {
-            uint256 value = loansContract.settings().chainlinkAggregator().valueFor(
-                loansContract.lendingToken(),
-                loansContract.collateralToken(),
-                uint256(
-                    neededInLendingTokens < 0
-                        ? -neededInLendingTokens
-                        : neededInLendingTokens
-                )
-            );
+            uint256 value =
+                loansContract.settings().chainlinkAggregator().valueFor(
+                    loansContract.lendingToken(),
+                    loansContract.collateralToken(),
+                    uint256(
+                        neededInLendingTokens < 0
+                            ? -neededInLendingTokens
+                            : neededInLendingTokens
+                    )
+                );
             neededInCollateralTokens = int256(value);
             if (neededInLendingTokens < 0) {
                 neededInCollateralTokens *= -1;
@@ -269,7 +288,11 @@ library LoanLib {
     function getCollateralNeededInTokens(
         TellerCommon.Loan storage loan,
         SettingsInterface settings
-    ) public view returns (int256 neededInLendingTokens, uint256 escrowLoanValue) {
+    )
+        public
+        view
+        returns (int256 neededInLendingTokens, uint256 escrowLoanValue)
+    {
         if (!isActiveOrSet(loan) || loan.loanTerms.collateralRatio == 0) {
             return (0, 0);
         }
@@ -289,20 +312,27 @@ library LoanLib {
                 loan.loanTerms.collateralRatio
             );
         } else {
-            neededInLendingTokens = int256(loan.principalOwed.add(loan.interestOwed));
-            uint256 bufferPercent = settings.getPlatformSettingValue(
-                settings.consts().COLLATERAL_BUFFER_SETTING()
+            neededInLendingTokens = int256(
+                loan.principalOwed.add(loan.interestOwed)
             );
-            uint256 requiredRatio = loan
-                .loanTerms
-                .collateralRatio
-                .sub(getInterestRatio(loan))
-                .sub(bufferPercent);
+            uint256 bufferPercent =
+                settings.getPlatformSettingValue(
+                    settings.consts().COLLATERAL_BUFFER_SETTING()
+                );
+            uint256 requiredRatio =
+                loan.loanTerms.collateralRatio.sub(getInterestRatio(loan)).sub(
+                    bufferPercent
+                );
             if (loan.escrow != address(0)) {
-                escrowLoanValue = EscrowInterface(loan.escrow).calculateTotalValue();
-                neededInLendingTokens += neededInLendingTokens - int256(escrowLoanValue);
+                escrowLoanValue = EscrowInterface(loan.escrow)
+                    .calculateTotalValue();
+                neededInLendingTokens = neededInLendingTokens.sub(
+                    int256(escrowLoanValue)
+                );
             }
-            neededInLendingTokens = neededInLendingTokens.percent(requiredRatio);
+            neededInLendingTokens = neededInLendingTokens.percent(
+                requiredRatio
+            );
         }
     }
 
@@ -315,20 +345,27 @@ library LoanLib {
     function getLiquidationInfo(
         TellerCommon.Loan storage loan,
         LoansInterface loansContract
-    ) public view returns (TellerCommon.LoanLiquidationInfo memory liquidationInfo) {
+    )
+        public
+        view
+        returns (TellerCommon.LoanLiquidationInfo memory liquidationInfo)
+    {
         liquidationInfo.collateralInfo = getCollateralInfo(loan, loansContract);
         liquidationInfo.amountToLiquidate = getTotalOwed(loan);
 
         // Maximum reward is the calculated value of required collateral minus the principal owed (see LoanLib.getCollateralNeededInTokens).+
-        uint256 availableValue = liquidationInfo.collateralInfo.valueInLendingTokens.add(
-            liquidationInfo.collateralInfo.escrowLoanValue
-        );
-        uint256 liquidationSetting = loansContract.settings().getPlatformSettingValue(
-            loansContract.settings().consts().LIQUIDATE_ETH_PRICE_SETTING()
-        );
-        uint256 maxReward = liquidationInfo.amountToLiquidate.percent(
-            liquidationSetting.diffOneHundredPercent()
-        );
+        uint256 availableValue =
+            liquidationInfo.collateralInfo.valueInLendingTokens.add(
+                liquidationInfo.collateralInfo.escrowLoanValue
+            );
+        uint256 liquidationSetting =
+            loansContract.settings().getPlatformSettingValue(
+                loansContract.settings().consts().LIQUIDATE_ETH_PRICE_SETTING()
+            );
+        uint256 maxReward =
+            liquidationInfo.amountToLiquidate.percent(
+                liquidationSetting.diffOneHundredPercent()
+            );
         if (availableValue < liquidationInfo.amountToLiquidate + maxReward) {
             liquidationInfo.rewardInCollateral = int256(availableValue);
         } else {


### PR DESCRIPTION
The audit states: 

> getCollateralNeededInTokens() in LoanLib library uses the += operator instead of a simple assignment meaning that the debt is counted twice. 
> 
> Change the operator to simply assign the result of the subtraction or document the decision of doubling the value of the loan. In either case, consider shielding the operation against underflows and overflows.

The logic is mean to add the difference of the `principalOwed` and the value of the escrow contract. Since the escrow value changes based on the tokens that it holds, the amount of required collateral can change based on this calculated difference.

A fix was made to add the `interestOwed` after the difference in value is calculated so that the interest amount is not included twice.