### PR TITLE
Fix Strict Dynamic Cache Update

### DIFF
--- a/contracts/base/MarketFactory.sol
+++ b/contracts/base/MarketFactory.sol
@@ -81,7 +81,7 @@ contract MarketFactory is IMarketFactory, Base, Factory {
         );
 
         address loanManagerAddress =
-            _createDynamicProxy(keccak256("LoanManager"));
+            _createDynamicProxy(keccak256("LoanManager"), true);
 
         LendingPoolInterface lendingPool =
             LendingPoolInterface(marketRegistry.lendingPools(lendingToken));
@@ -118,7 +118,7 @@ contract MarketFactory is IMarketFactory, Base, Factory {
         erc20DynamicProxyLogic = address(new ERC20DynamicProxy());
 
         marketRegistry = IMarketRegistry(
-            _createDynamicProxy(keccak256("MarketRegistry"))
+            _createDynamicProxy(keccak256("MarketRegistry"), false)
         );
         marketRegistry.initialize();
     }
@@ -129,7 +129,7 @@ contract MarketFactory is IMarketFactory, Base, Factory {
         @notice It creates a InitializeableDynamicProxy instance for a given logic name.
         @dev It is used to create all the market contracts as strict dynamic proxies.
      */
-    function _createDynamicProxy(bytes32 logicName)
+    function _createDynamicProxy(bytes32 logicName, bool strict)
         internal
         returns (address proxyAddress)
     {
@@ -137,7 +137,7 @@ contract MarketFactory is IMarketFactory, Base, Factory {
         IInitializeableDynamicProxy(proxyAddress).initialize(
             address(logicRegistry),
             logicName,
-            true
+            strict
         );
     }
 
@@ -162,7 +162,7 @@ contract MarketFactory is IMarketFactory, Base, Factory {
         returns (LendingPoolInterface lendingPool)
     {
         lendingPool = LendingPoolInterface(
-            _createDynamicProxy(keccak256("LendingPool"))
+            _createDynamicProxy(keccak256("LendingPool"), true)
         );
 
         ITToken tToken = ITToken(_createTTokenProxy());

--- a/contracts/base/escrow/Escrow.sol
+++ b/contracts/base/escrow/Escrow.sol
@@ -47,6 +47,7 @@ contract Escrow is IEscrow, Base, EscrowStorage, BaseEscrowDapp {
      */
     function callDapp(TellerCommon.DappData calldata dappData)
         external
+        updateImpIfNeeded
         onlyBorrower
         whenNotPaused
     {
@@ -100,7 +101,12 @@ contract Escrow is IEscrow, Base, EscrowStorage, BaseEscrowDapp {
      * @dev If the Escrow's balance of the borrowed token is less than the amount to repay, transfer tokens from the sender's wallet.
      * @dev Only the owner of the Escrow can call this. If someone else wants to make a payment, they should call the loan manager directly.
      */
-    function repay(uint256 amount) external onlyBorrower whenNotPaused {
+    function repay(uint256 amount)
+        external
+        updateImpIfNeeded
+        onlyBorrower
+        whenNotPaused
+    {
         IERC20 token = IERC20(lendingToken);
         uint256 balance = _balanceOf(address(token));
         uint256 totalOwed = loanManager.getTotalOwed(loanID);
@@ -122,7 +128,12 @@ contract Escrow is IEscrow, Base, EscrowStorage, BaseEscrowDapp {
      * @dev The loan must not be active.
      * @dev The recipient must be the loan borrower AND the loan must be already liquidated.
      */
-    function claimTokens() external onlyBorrower whenNotPaused {
+    function claimTokens()
+        external
+        updateImpIfNeeded
+        onlyBorrower
+        whenNotPaused
+    {
         require(
             loanManager.loans(loanID).status == TellerCommon.LoanStatus.Closed,
             "LOAN_NOT_CLOSED"
@@ -149,6 +160,7 @@ contract Escrow is IEscrow, Base, EscrowStorage, BaseEscrowDapp {
      */
     function claimTokensByCollateralValue(address recipient, uint256 value)
         external
+        updateImpIfNeeded
         whenNotPaused
     {
         require(

--- a/contracts/base/lending-pool/LendingPool.sol
+++ b/contracts/base/lending-pool/LendingPool.sol
@@ -81,6 +81,7 @@ contract LendingPool is
     */
     function deposit(uint256 lendingTokenAmount)
         external
+        updateImpIfNeeded
         nonReentrant
         whenNotPaused
         whenLendingPoolNotPaused(address(this))
@@ -125,6 +126,7 @@ contract LendingPool is
      */
     function withdraw(uint256 lendingTokenAmount)
         external
+        updateImpIfNeeded
         nonReentrant
         whenNotPaused
         whenLendingPoolNotPaused(address(this))
@@ -145,6 +147,7 @@ contract LendingPool is
 
     function withdrawAll()
         external
+        updateImpIfNeeded
         nonReentrant
         whenNotPaused
         whenLendingPoolNotPaused(address(this))
@@ -176,6 +179,7 @@ contract LendingPool is
         address borrower
     )
         external
+        updateImpIfNeeded
         nonReentrant
         isLoan
         whenLendingPoolNotPaused(address(this))
@@ -206,6 +210,7 @@ contract LendingPool is
      */
     function createLoan(uint256 amount, address borrower)
         external
+        updateImpIfNeeded
         nonReentrant
         isLoan
         whenLendingPoolNotPaused(address(this))
@@ -222,12 +227,13 @@ contract LendingPool is
         _totalBorrowed = _totalBorrowed.add(amount);
     }
 
-    function swapAccumulatedComp() external {
+    function swapAccumulatedComp() external updateImpIfNeeded {
         _swapAccumulatedComp();
     }
 
     function getMarketStateCurrent()
         external
+        updateImpIfNeeded
         returns (
             uint256 totalSupplied,
             uint256 totalBorrowed,
@@ -261,7 +267,11 @@ contract LendingPool is
         of TTokens owned and the current exchange rate.
         @return a lender's balance of the underlying token in the pool.
      */
-    function balanceOfUnderlying(address lender) external returns (uint256) {
+    function balanceOfUnderlying(address lender)
+        external
+        updateImpIfNeeded
+        returns (uint256)
+    {
         return
             _lendingTokensFromTTokens(
                 tToken.balanceOf(lender),
@@ -276,6 +286,7 @@ contract LendingPool is
      */
     function getLenderInterestEarned(address lender)
         external
+        updateImpIfNeeded
         returns (uint256)
     {
         uint256 currentLenderInterest =
@@ -289,6 +300,7 @@ contract LendingPool is
      */
     function getClaimableInterestEarned(address lender)
         external
+        updateImpIfNeeded
         returns (uint256)
     {
         return _calculateLenderInterestEarned(lender, _exchangeRateCurrent());
@@ -324,7 +336,11 @@ contract LendingPool is
         @notice It calculates the current exchange rate for the TToken based on the total supply of the lending token.
         @return the exchange rate for 1 TToken to the underlying token.
      */
-    function exchangeRateCurrent() external returns (uint256) {
+    function exchangeRateCurrent()
+        external
+        updateImpIfNeeded
+        returns (uint256)
+    {
         return _exchangeRateCurrent();
     }
 
@@ -338,6 +354,7 @@ contract LendingPool is
 
     function tTokensFromLendingTokens(uint256 lendingTokenAmount)
         external
+        updateImpIfNeeded
         returns (uint256)
     {
         return
@@ -349,6 +366,7 @@ contract LendingPool is
 
     function lendingTokensFromTTokens(uint256 tTokenAmount)
         external
+        updateImpIfNeeded
         returns (uint256)
     {
         return _lendingTokensFromTTokens(tTokenAmount, _exchangeRateCurrent());

--- a/contracts/base/loans/LoanManager.sol
+++ b/contracts/base/loans/LoanManager.sol
@@ -336,6 +336,7 @@ contract LoanManager is ILoanManager, Base, LoanStorage, Factory {
     )
         external
         payable
+        updateImpIfNeeded
         nonReentrant
         whenNotPaused
         withValidLoanRequest(request)
@@ -379,6 +380,7 @@ contract LoanManager is ILoanManager, Base, LoanStorage, Factory {
      */
     function withdrawCollateral(uint256 amount, uint256 loanID)
         external
+        updateImpIfNeeded
         nonReentrant
         loanActiveOrSet(loanID)
         whenNotPaused
@@ -428,6 +430,7 @@ contract LoanManager is ILoanManager, Base, LoanStorage, Factory {
     )
         external
         payable
+        updateImpIfNeeded
         loanActiveOrSet(loanID)
         whenNotPaused
         whenLendingPoolNotPaused(address(lendingPool))
@@ -452,6 +455,7 @@ contract LoanManager is ILoanManager, Base, LoanStorage, Factory {
      */
     function takeOutLoan(uint256 loanID, uint256 amountBorrow)
         external
+        updateImpIfNeeded
         nonReentrant
         whenNotPaused
         whenLendingPoolNotPaused(address(lendingPool))
@@ -525,6 +529,7 @@ contract LoanManager is ILoanManager, Base, LoanStorage, Factory {
      */
     function repay(uint256 amount, uint256 loanID)
         external
+        updateImpIfNeeded
         nonReentrant
         loanActive(loanID)
         whenNotPaused
@@ -589,6 +594,7 @@ contract LoanManager is ILoanManager, Base, LoanStorage, Factory {
      */
     function liquidateLoan(uint256 loanID)
         external
+        updateImpIfNeeded
         nonReentrant
         loanActive(loanID)
         whenNotPaused
@@ -628,7 +634,7 @@ contract LoanManager is ILoanManager, Base, LoanStorage, Factory {
         @dev The sender must be the owner.
         @dev It throws a require error if the sender is not the owner.
      */
-    function addSigner(address account) external onlyPauser {
+    function addSigner(address account) external updateImpIfNeeded onlyPauser {
         _delegateTo(
             loanTermsConsensus,
             abi.encodeWithSignature("addSigner(address)", account)
@@ -641,7 +647,11 @@ contract LoanManager is ILoanManager, Base, LoanStorage, Factory {
         @dev The sender must be the owner.
         @dev It throws a require error if the sender is not the owner.
      */
-    function addSigners(address[] calldata accounts) external onlyPauser {
+    function addSigners(address[] calldata accounts)
+        external
+        updateImpIfNeeded
+        onlyPauser
+    {
         _delegateTo(
             loanTermsConsensus,
             abi.encodeWithSignature("addSigners(address[])", accounts)

--- a/contracts/base/upgradeable/DynamicUpgradeable.sol
+++ b/contracts/base/upgradeable/DynamicUpgradeable.sol
@@ -23,6 +23,11 @@ import "./DynamicUpgradeableStorage.sol";
 contract DynamicUpgradeable is DynamicUpgradeableStorage {
     /* Modifiers */
 
+    /**
+     * @notice It checks if the proxy's implementation cache is invalidated and should be updated.
+     * @dev Any external, non-view function should use this modifier.
+     * @dev This modifier should be the very FIRST modifier for functions.
+     */
     modifier updateImpIfNeeded() {
         if (_cacheInvalidated()) {
             _updateImplementationStored();
@@ -32,6 +37,10 @@ contract DynamicUpgradeable is DynamicUpgradeableStorage {
 
     /* External Functions */
 
+    /**
+     * @notice It updates a proxy's cached implementation address.
+     * @notice It must only be called by the LogicVersionsRegistry for non strict DynamicProxy
+     */
     function upgradeProxyTo(address newImplementation) public {
         require(msg.sender == address(logicRegistry), "MUST_BE_LOGIC_REGISTRY");
         implementationStored = newImplementation;
@@ -67,9 +76,13 @@ contract DynamicUpgradeable is DynamicUpgradeableStorage {
         _implementationBlockUpdated = block.number;
     }
 
+    /**
+     * @notice It checks if the current cached address implementation is marked as invalidated.
+     * @notice It is marked invalidated if the proxy is strict dynamic and last update was >= 50 blocks ago.
+     * @return bool True if the cached implementation address is invalid.
+     */
     function _cacheInvalidated() internal view returns (bool) {
-        return
-            strictDynamic && _implementationBlockUpdated + 50 <= block.number;
+        return strictDynamic && _implementationBlockUpdated + 1 <= block.number;
     }
 
     /**

--- a/test/integration/loans.test.ts
+++ b/test/integration/loans.test.ts
@@ -128,7 +128,8 @@ describe('LoanManager', async () => {
           createdLoan.createdLoanId,
           await borrower.getAddress(),
           createdLoan.totalOwed,
-          await borrower.getAddress()
+          await borrower.getAddress(),
+          '0'
         )
     })
     // - Taking out a loan unsuccessfully with invalid debt ratio


### PR DESCRIPTION
It only updates `DynamicProxy` cached address via a modifier. 
Each function in a contract that extends the `DynamicUpgradeable` contract that is `external` and **NOT** `view` should use this modifier as the very _**FIRST**_ modifer so that if the logic needs to be updated, other modifiers get the applied update.