### PR TITLE
Update Mainnet Forking Block Number 

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -60,7 +60,7 @@ const networkUrls: { [network: string]: string } = {
 }
 
 const networkForkingBlock: { [network: string]: number } = {
-  mainnet: 12480795,
+  mainnet: 12648380,
   // polygon: 14891625,
   // polygon_mumbai: 14244031,
 }


### PR DESCRIPTION
Sets the block number to fork mainnet to after the latest deployment