### PR TITLE
Fix Deploy NFT Script

### DIFF
--- a/deploy/nft.ts
+++ b/deploy/nft.ts
@@ -23,30 +23,18 @@ const deployNFT: DeployFunction = async (hre) => {
     hre,
   })
 
-  /** TODO */
-
-  let proxyMethodName: string | undefined
-  let proxyMethodArgs: any[] | undefined
-
-  try {
-    // Try to get deployment of TellerDiamond
-    await contracts.get('TellerNFTDictionary')
-
-    proxyMethodName = undefined
-    proxyMethodArgs = undefined
-  } catch (e) {
-    proxyMethodName = 'initialize' //call this method on deployment
-    proxyMethodArgs = [await deployer.getAddress()]
-  }
-
   const nftDictionary = await deploy<TellerNFTDictionary>({
     contract: 'TellerNFTDictionary',
     hre,
     proxy: {
       proxyContract: 'OpenZeppelinTransparentProxy',
-      methodName: proxyMethodName,
+      execute: {
+        init: {
+          methodName: 'initialize',
+          args: [await deployer.getAddress()],
+        },
+      },
     },
-    args: proxyMethodArgs,
   })
 
   //call initialize on the dictionary

--- a/utils/deploy-helpers.ts
+++ b/utils/deploy-helpers.ts
@@ -2,7 +2,7 @@ import colors from 'colors'
 import { makeNodeDisklet } from 'disklet'
 import { Contract } from 'ethers'
 import { HardhatRuntimeEnvironment } from 'hardhat/types'
-import { DeployOptions, DeployResult } from 'hardhat-deploy/dist/types'
+import { DeployOptions, DeployResult } from 'hardhat-deploy/types'
 import { Libraries } from 'hardhat-deploy/types'
 
 interface CommonDeployArgs extends Omit<DeployOptions, 'from'> {
@@ -30,8 +30,6 @@ export const deploy = async <C extends Contract>(
     ethers,
   } = hre
 
-  const log = args.log === false ? (...args: any[]) => {} : args.hre.log
-
   const { deployer } = await getNamedAccounts()
   const contractDeployName = args.name ?? args.contract
   const existingContract = await getOrNull(contractDeployName)
@@ -53,6 +51,7 @@ export const deploy = async <C extends Contract>(
     contractAddress = existingContract.address
     await onDeployResult({
       result: { ...existingContract, newlyDeployed: false },
+      name: contractDeployName,
       hre,
       indent,
     })


### PR DESCRIPTION
An upgrade was made to the `hardhat-deploy` package that broke the deploy script for proxy contracts.