### PR TITLE
Run yarn build && eslint for staged files on commit

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,12 +76,12 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "lint-staged"
+      "pre-commit": "yarn build && lint-staged"
     }
   },
   "lint-staged": {
-    "*.{sol,js,ts,json,md}": [
-      "prettier --write"
+    "*.{sol,js,ts}": [
+      "eslint --fix"
     ]
   }
 }


### PR DESCRIPTION
Files are not being linted and type checked before being committed. This update runs `yarn build && eslint --fix` on staged files before the commit is made.