### PR TITLE
Fork Network Using Latest Deployment Block

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -7,12 +7,14 @@ import 'hardhat-gas-reporter'
 
 import { config } from 'dotenv'
 import { BigNumber as BN, ethers } from 'ethers'
+import fs from 'fs'
 import { HardhatUserConfig } from 'hardhat/config'
 import {
   HardhatNetworkHDAccountsUserConfig,
   HardhatNetworkUserConfig,
   NetworkUserConfig,
 } from 'hardhat/types'
+import path from 'path'
 
 config()
 
@@ -59,11 +61,19 @@ const networkUrls: { [network: string]: string } = {
   polygon_mumbai: MATIC_MUMBAI_KEY!,
 }
 
-const networkForkingBlock: { [network: string]: number } = {
-  mainnet: 12648380,
-  // polygon: 14891625,
-  // polygon_mumbai: 14244031,
-}
+const getLatestDeploymentBlock = (networkName: string): number =>
+  parseInt(
+    fs
+      .readFileSync(
+        path.resolve(
+          __dirname,
+          'deployments',
+          networkName,
+          '.latestDeploymentBlock'
+        )
+      )
+      .toString()
+  )
 
 const networkConfig = (config: NetworkUserConfig): NetworkUserConfig => {
   config = {
@@ -195,7 +205,7 @@ export default <HardhatUserConfig>{
           : {
               enabled: true,
               url: networkUrls[FORKING_NETWORK],
-              blockNumber: networkForkingBlock[FORKING_NETWORK],
+              blockNumber: getLatestDeploymentBlock(FORKING_NETWORK),
             },
     }),
     localhost: networkConfig({


### PR DESCRIPTION
The block used to fork a network locally, for tests and other operations, was previously hard coded in the `hardhat.config.ts` file which made it cumbersome to manually update this value after a new deployment. 

We are already saving a file in the `deployments` directory for each network called `.latestDeploymentBlock` that is updated during the deployment process. This value is now being loaded during these operations.