### PR TITLE
 [PROTOCOL-648] [N04] Typographical errors

### DIFF
--- a/contracts/lending/ttoken/ITToken.sol
+++ b/contracts/lending/ttoken/ITToken.sol
@@ -35,7 +35,7 @@ abstract contract ITToken is ERC20Upgradeable, RolesFacet {
     );
 
     /**
-     * @notice The token that is the underlying assets for this Teller token.
+     * @notice The token that is the underlying asset for this Teller token.
      * @return ERC20 token
      */
     function underlying() external view virtual returns (ERC20);

--- a/contracts/lending/ttoken/ITToken.sol
+++ b/contracts/lending/ttoken/ITToken.sol
@@ -51,7 +51,7 @@ abstract contract ITToken is ERC20Upgradeable, RolesFacet {
         returns (uint256 balance_);
 
     /**
-     * @notice It calculates the current exchange rate for a whole Teller Token based of the underlying token balance.
+     * @notice It calculates the current exchange rate for a whole Teller Token based off the underlying token balance.
      * @return rate_ The current exchange rate.
      */
     function exchangeRate() external virtual returns (uint256 rate_);
@@ -102,7 +102,6 @@ abstract contract ITToken is ERC20Upgradeable, RolesFacet {
         external
         virtual
         returns (uint16 ratio_);
-        
 
     /**
      * @notice Called by the Teller Diamond contract when a loan has been taken out and requires funds.
@@ -129,7 +128,7 @@ abstract contract ITToken is ERC20Upgradeable, RolesFacet {
         returns (uint256 mintAmount_);
 
     /**
-     * @notice Redeem supplied Teller token underlying value.
+     * @notice Redeem supplied Teller tokens for underlying value.
      * @param amount The amount of Teller tokens to redeem.
      */
     function redeem(uint256 amount) external virtual;

--- a/contracts/lending/ttoken/TToken_V1.sol
+++ b/contracts/lending/ttoken/TToken_V1.sol
@@ -67,8 +67,8 @@ contract TToken_V1 is ITToken {
     }
 
     /**
-     * @notice The token that is the underlying assets for this Teller token.
-     * @return ERC20 token that is the underl
+     * @notice The token that is the underlying asset for this Teller token.
+     * @return ERC20 token that is the underlying asset
      */
     function underlying() public view override returns (ERC20) {
         return s().underlying;
@@ -88,7 +88,7 @@ contract TToken_V1 is ITToken {
     }
 
     /**
-     * @notice It calculates the current exchange rate for a whole Teller Token based of the underlying token balance.
+     * @notice It calculates the current exchange rate for a whole Teller Token based off the underlying token balance.
      * @return rate_ The current exchange rate.
      */
     function exchangeRate() public override returns (uint256 rate_) {
@@ -114,7 +114,7 @@ contract TToken_V1 is ITToken {
     }
 
     /**
-     * @notice It calculates the market state values across a given markets.
+     * @notice It calculates the market state values across a given market.
      * @notice Returns values that represent the global state across the market.
      * @return totalSupplied Total amount of the underlying asset supplied.
      * @return totalBorrowed Total amount borrowed through loans.
@@ -251,7 +251,7 @@ contract TToken_V1 is ITToken {
     }
 
     /**
-     * @notice Redeem supplied Teller token underlying value.
+     * @notice Redeem supplied Teller tokens for underlying value.
      * @param amount The amount of Teller tokens to redeem.
      */
     function redeem(uint256 amount) external override {
@@ -432,7 +432,7 @@ contract TToken_V1 is ITToken {
     }
 
     /**
-     * @notice it retrives the value in the underlying tokens
+     * @notice it retrieves the value in the underlying tokens
      *
      */
     function _valueInUnderlying(uint256 amount, uint256 rate)


### PR DESCRIPTION
fixed all typographical errors stated

```
Line 70 of TToken_V1.sol and line 38 of ITToken.sol say “assets” instead of “asset”.

Line 71 of TToken_V1.sol has been truncated.

Line 91 of TToken_V1.sol and line 54 of ITToken.sol say “of” instead of “off” (or “on”).

Line 117 of TToken_V1.sol says “markets” instead of “market”.

Line 251 of TToken_V1.sol and line 132 of ITToken.sol say “token underlying” instead of “tokens for underlying”.

Line 427 of TToken_V1.sol says “retrives” instead of “retrieves”.
```