### PR TITLE
[PROTOCOL-645] [N01] Misleading comments

### DIFF
--- a/contracts/lending/ttoken/ITToken.sol
+++ b/contracts/lending/ttoken/ITToken.sol
@@ -96,13 +96,12 @@ abstract contract ITToken is ERC20Upgradeable, RolesFacet {
     /**
      * @notice It validates whether supply to debt (StD) ratio is valid including the loan amount.
      * @param newLoanAmount the new loan amount to consider the StD ratio.
-     * @return ratio_ Whether debt ratio for lending pool is valid.
+     * @return ratio_ The debt ratio for lending pool.
      */
     function debtRatioFor(uint256 newLoanAmount)
         external
         virtual
         returns (uint16 ratio_);
-        
 
     /**
      * @notice Called by the Teller Diamond contract when a loan has been taken out and requires funds.

--- a/contracts/lending/ttoken/TToken_V1.sol
+++ b/contracts/lending/ttoken/TToken_V1.sol
@@ -43,7 +43,7 @@ contract TToken_V1 is ITToken {
     /* Modifiers */
 
     /**
-     * @notice Checks if the LP is restricted or has the CONTROLLER role.
+     * @notice Checks if the LP is restricted or the message sender has the CONTROLLER role.
      *
      * The LP being restricted means that only the Teller protocol may
      *  lend/borrow funds.
@@ -155,7 +155,7 @@ contract TToken_V1 is ITToken {
     /**
      * @notice It validates whether supply to debt (StD) ratio is valid including the loan amount.
      * @param newLoanAmount the new loan amount to consider the StD ratio.
-     * @return ratio_ Whether debt ratio for lending pool is valid.
+     * @return ratio_ The debt ratio for lending pool.
      */
     function debtRatioFor(uint256 newLoanAmount)
         external
@@ -332,7 +332,7 @@ contract TToken_V1 is ITToken {
     }
 
     /**
-     * @notice Sets a new strategy to use for balancing funds.
+     * @notice Sets or updates a strategy to use for balancing funds.
      * @param strategy Address to the new strategy contract. Must implement the {ITTokenStrategy} interface.
      * @param initData Optional data to initialize the strategy.
      *
@@ -425,7 +425,7 @@ contract TToken_V1 is ITToken {
 
     /**
      * @notice it retrives the value in the underlying tokens
-     * 
+     *
      */
     function _valueInUnderlying(uint256 amount, uint256 rate)
         internal
@@ -439,8 +439,6 @@ contract TToken_V1 is ITToken {
      * @notice Delegates data to call on the strategy contract.
      * @param callData Data to call the strategy contract with.
      *
-     * Requirements:
-     *  - Sender must have ADMIN role
      */
     function _delegateStrategy(bytes memory callData)
         internal

--- a/contracts/lending/ttoken/strategies/compound/TTokenCompoundStrategy_1.sol
+++ b/contracts/lending/ttoken/strategies/compound/TTokenCompoundStrategy_1.sol
@@ -103,7 +103,7 @@ contract TTokenCompoundStrategy_1 is RolesMods, TTokenStrategy {
     /**
      * @notice it gets balances and the current ratio of the underlying asset stored on the TToken.
      * @return storedBalance_ returns the total stored balance of the current underlying token
-     * @return compoundBalance_ returns the total stored balance
+     * @return compoundBalance_ returns the amount of underlying value stored in Compound
      * @return storedRatio_ ratio of current storedBalance_ over storedBalance_ and compoundBalance_
      */
     function _getBalanceInfo()


### PR DESCRIPTION
Removed misleading comments

```
In TToken_V1.sol:

- Line 46 implies a valid condition is if the lending pool “has the CONTROLLER role”. This should say “the message sender has the CONTROLLER role”.

- Line 158 suggests debtRatioFor returns a boolean, but it just returns the ratio without indicating whether it is valid. This mistake is repeated in ITToken.

- Line 443 states the message sender “must have ADMIN role”. There is no such restriction.

- Line 335 states “Sets a new strategy to use for balancing funds”, however the setStrategy function can also be used to update the parameters of the current strategy instead of replacing it with a new one.

In TTokenCompoundStrategy_1:

- Line 106 says compoundBalance_ is the total stored balance, but it is the amount of underlying value stored in Compound.


```