### PR TITLE
[PROTOCOL-636] [M03] Lack of event emission after sensitive actions

### DIFF
--- a/contracts/lending/ttoken/ITToken.sol
+++ b/contracts/lending/ttoken/ITToken.sol
@@ -31,6 +31,25 @@ abstract contract ITToken is ERC20Upgradeable, RolesFacet {
     );
 
     /**
+     * @notice This event is emitted when a loan has been taken out through the Teller Diamond.
+     * @param recipient The address receiving the borrowed funds.
+     * @param totalBorrowed The total amount being loaned out by the tToken.
+     */
+    event LoanFunded(address indexed recipient, uint256 totalBorrowed);
+
+    /**
+     * @notice This event is emitted when a loan has been repaid through the Teller Diamond.
+     * @param sender The address making the payment to the tToken.
+     * @param principlePayment The amount paid back towards the principle loaned out by the tToken.
+     * @param interestPayment The amount paid back towards the interest owed to the tToken.
+     */
+    event LoanPaymentMade(
+        address indexed sender,
+        uint256 principlePayment,
+        uint256 interestPayment
+    );
+
+    /**
      * @notice This event is emitted when the platform restriction is switched
      * @param restriction Boolean representing the state of the restriction
      * @param investmentManager address of the investment manager flipping the switch

--- a/contracts/lending/ttoken/ITToken.sol
+++ b/contracts/lending/ttoken/ITToken.sol
@@ -50,6 +50,13 @@ abstract contract ITToken is ERC20Upgradeable, RolesFacet {
     );
 
     /**
+     * @notice This event is emitted when a new investment management strategy has been set for a Teller token.
+     * @param strategyAddress The address of the new strategy set for managing the underlying assets held by the tToken.
+     * @param sender The address of the sender setting the token strategy.
+     */
+    event StrategySet(address strategyAddress, address indexed sender);
+
+    /**
      * @notice This event is emitted when the platform restriction is switched
      * @param restriction Boolean representing the state of the restriction
      * @param investmentManager address of the investment manager flipping the switch

--- a/contracts/lending/ttoken/ITToken.sol
+++ b/contracts/lending/ttoken/ITToken.sol
@@ -2,13 +2,9 @@
 pragma solidity ^0.8.0;
 
 // Contracts
-import {
-    ERC20Upgradeable
-} from "@openzeppelin/contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol";
+import { ERC20Upgradeable } from "@openzeppelin/contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol";
 import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
-import {
-    RolesFacet
-} from "../../contexts2/access-control/roles/RolesFacet.sol";
+import { RolesFacet } from "../../contexts2/access-control/roles/RolesFacet.sol";
 
 /**
  * @notice This contract acts as an interface for the Teller token (TToken).
@@ -32,6 +28,16 @@ abstract contract ITToken is ERC20Upgradeable, RolesFacet {
         address indexed sender,
         uint256 tTokenAmount,
         uint256 underlyingAmount
+    );
+
+    /**
+     * @notice This event is emitted when the platform restriction is switched
+     * @param restriction Boolean representing the state of the restriction
+     * @param investmentManager address of the investment manager flipping the switch
+     */
+    event PlatformRestricted(
+        bool restriction,
+        address indexed investmentManager
     );
 
     /**
@@ -102,7 +108,6 @@ abstract contract ITToken is ERC20Upgradeable, RolesFacet {
         external
         virtual
         returns (uint16 ratio_);
-        
 
     /**
      * @notice Called by the Teller Diamond contract when a loan has been taken out and requires funds.

--- a/contracts/lending/ttoken/TToken_V1.sol
+++ b/contracts/lending/ttoken/TToken_V1.sol
@@ -2,12 +2,7 @@
 pragma solidity ^0.8.0;
 
 // Contracts
-import {
-    CONTROLLER,
-    ADMIN,
-    EXCHANGE_RATE_FACTOR,
-    ONE_HUNDRED_PERCENT
-} from "./data.sol";
+import { CONTROLLER, ADMIN, EXCHANGE_RATE_FACTOR, ONE_HUNDRED_PERCENT } from "./data.sol";
 import { ITTokenStrategy } from "./strategies/ITTokenStrategy.sol";
 import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 
@@ -19,13 +14,8 @@ import { ITToken } from "./ITToken.sol";
 import { ICErc20 } from "../../shared/interfaces/ICErc20.sol";
 
 // Libraries
-import {
-    IERC20,
-    SafeERC20
-} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
-import {
-    ERC165Checker
-} from "@openzeppelin/contracts/utils/introspection/ERC165Checker.sol";
+import { IERC20, SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import { ERC165Checker } from "@openzeppelin/contracts/utils/introspection/ERC165Checker.sol";
 import { RolesLib } from "../../contexts2/access-control/roles/RolesLib.sol";
 import { NumbersLib } from "../../shared/libraries/NumbersLib.sol";
 
@@ -104,12 +94,11 @@ contract TToken_V1 is ITToken {
      * @return totalSupply_ the total supply denoted in the underlying asset.
      */
     function totalUnderlyingSupply() public override returns (uint256) {
-        bytes memory data =
-            _delegateStrategy(
-                abi.encodeWithSelector(
-                    ITTokenStrategy.totalUnderlyingSupply.selector
-                )
-            );
+        bytes memory data = _delegateStrategy(
+            abi.encodeWithSelector(
+                ITTokenStrategy.totalUnderlyingSupply.selector
+            )
+        );
         return abi.decode(data, (uint256));
     }
 
@@ -366,7 +355,7 @@ contract TToken_V1 is ITToken {
     }
 
     /**
-     * @notice Sets the restricted state of the platform.
+     * @notice Sets the restricted state of the tToken.
      * @param state boolean value that resembles the platform's state
      */
     function restrict(bool state)
@@ -375,6 +364,7 @@ contract TToken_V1 is ITToken {
         authorized(ADMIN, _msgSender())
     {
         s().restricted = state;
+        emit PlatformRestricted(state, _msgSender());
     }
 
     /**
@@ -425,7 +415,7 @@ contract TToken_V1 is ITToken {
 
     /**
      * @notice it retrives the value in the underlying tokens
-     * 
+     *
      */
     function _valueInUnderlying(uint256 amount, uint256 rate)
         internal

--- a/contracts/lending/ttoken/TToken_V1.sol
+++ b/contracts/lending/ttoken/TToken_V1.sol
@@ -346,6 +346,7 @@ contract TToken_V1 is ITToken {
         if (initData.length > 0) {
             _delegateStrategy(initData);
         }
+        emit StrategySet(strategy, _msgSender());
     }
 
     /**

--- a/contracts/lending/ttoken/TToken_V1.sol
+++ b/contracts/lending/ttoken/TToken_V1.sol
@@ -184,6 +184,7 @@ contract TToken_V1 is ITToken {
 
         // Transfer tokens to recipient
         SafeERC20.safeTransfer(s().underlying, recipient, amount);
+        emit LoanFunded(recipient, amount);
     }
 
     /**
@@ -198,6 +199,7 @@ contract TToken_V1 is ITToken {
     {
         s().totalRepaid += amount;
         s().totalInterestRepaid += interestAmount;
+        emit LoanPaymentMade(_msgSender(), amount, interestAmount);
     }
 
     /**

--- a/contracts/lending/ttoken/strategies/ITTokenStrategy.sol
+++ b/contracts/lending/ttoken/strategies/ITTokenStrategy.sol
@@ -2,8 +2,25 @@
 pragma solidity ^0.8.0;
 
 interface ITTokenStrategy {
+    /**
+     * @notice This event is emitted when the underlying assets are rebalanced as directed by the set investment strategy.
+     * @param strategyName The name of the strategy being rebalanced - example: "CompoundStrategy_1"
+     * @param sender The address of the sender rebalancing the token strategy.
+     */
     event StrategyRebalanced(
         string indexed strategyName,
+        address indexed sender
+    );
+
+    /**
+     * @notice This event is emitted when the underlying assets are rebalanced as directed by the set investment strategy.
+     * @param strategyName The name of the strategy being rebalanced - example: "CompoundStrategy_1"
+     * @param investmentAsset The address of the investible asset / protocol being used to leverage the underlying assets.
+     * @param sender The address of the sender rebalancing the token strategy.
+     */
+    event StrategyInitialized(
+        string indexed strategyName,
+        address investmentAsset,
         address indexed sender
     );
 
@@ -15,7 +32,6 @@ interface ITTokenStrategy {
 
     /**
      * @notice it rebalances the underlying asset held by the Teller Token.
-     *
      */
     function rebalance() external;
 


### PR DESCRIPTION
Adding event emissions to the following relevant events:
- The restrict function from the TToken_V1 contract.
- The repayLoan function from the TToken_V1 contract when a loan has been repaid.
- The fundLoan function from the TToken_V1 contract when a loan has been taken out.
- The setStrategy function from the TToken_V1 contract.
- The init function from the TTokenCompoundStrategy_1 contract when setting new parameters for the strategy.