### PR TITLE
[PROTOCOL-637] [L01] Missing docstrings

### DIFF
--- a/contracts/lending/ttoken/TToken_V1.sol
+++ b/contracts/lending/ttoken/TToken_V1.sol
@@ -2,12 +2,7 @@
 pragma solidity ^0.8.0;
 
 // Contracts
-import {
-    CONTROLLER,
-    ADMIN,
-    EXCHANGE_RATE_FACTOR,
-    ONE_HUNDRED_PERCENT
-} from "./data.sol";
+import { CONTROLLER, ADMIN, EXCHANGE_RATE_FACTOR, ONE_HUNDRED_PERCENT } from "./data.sol";
 import { ITTokenStrategy } from "./strategies/ITTokenStrategy.sol";
 import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 
@@ -19,13 +14,8 @@ import { ITToken } from "./ITToken.sol";
 import { ICErc20 } from "../../shared/interfaces/ICErc20.sol";
 
 // Libraries
-import {
-    IERC20,
-    SafeERC20
-} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
-import {
-    ERC165Checker
-} from "@openzeppelin/contracts/utils/introspection/ERC165Checker.sol";
+import { IERC20, SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import { ERC165Checker } from "@openzeppelin/contracts/utils/introspection/ERC165Checker.sol";
 import { RolesLib } from "../../contexts2/access-control/roles/RolesLib.sol";
 import { NumbersLib } from "../../shared/libraries/NumbersLib.sol";
 
@@ -88,8 +78,8 @@ contract TToken_V1 is ITToken {
     }
 
     /**
-     * @notice It calculates the current exchange rate for a whole Teller Token based of the underlying token balance.
-     * @return rate_ The current exchange rate.
+     * @notice It calculates the current scaled exchange rate for a whole Teller Token based of the underlying token balance.
+     * @return rate_ The current exchange rate, scaled by the EXCHANGE_RATE_FACTOR.
      */
     function exchangeRate() public override returns (uint256 rate_) {
         if (totalSupply() == 0) {
@@ -104,12 +94,11 @@ contract TToken_V1 is ITToken {
      * @return totalSupply_ the total supply denoted in the underlying asset.
      */
     function totalUnderlyingSupply() public override returns (uint256) {
-        bytes memory data =
-            _delegateStrategy(
-                abi.encodeWithSelector(
-                    ITTokenStrategy.totalUnderlyingSupply.selector
-                )
-            );
+        bytes memory data = _delegateStrategy(
+            abi.encodeWithSelector(
+                ITTokenStrategy.totalUnderlyingSupply.selector
+            )
+        );
         return abi.decode(data, (uint256));
     }
 
@@ -212,6 +201,7 @@ contract TToken_V1 is ITToken {
     }
 
     /**
+     * @dev The tToken contract needs to have been granted sufficient allowance to transfer the amount being used to mint.
      * @notice Deposit underlying token amount into LP and mint tokens.
      * @param amount The amount of underlying tokens to use to mint.
      * @return Amount of TTokens minted.
@@ -425,7 +415,7 @@ contract TToken_V1 is ITToken {
 
     /**
      * @notice it retrives the value in the underlying tokens
-     * 
+     *
      */
     function _valueInUnderlying(uint256 amount, uint256 rate)
         internal

--- a/contracts/lending/ttoken/storage.sol
+++ b/contracts/lending/ttoken/storage.sol
@@ -4,12 +4,19 @@ pragma solidity ^0.8.0;
 import { ERC20, IERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 
 struct Store {
+    // The underlying asset of the tToken
     ERC20 underlying;
+    // The address of the investment strategy contract managing the underlying assets
     address strategy;
+    // The total amount of the underlying asset currently out in disbursed loans
     uint256 totalBorrowed;
+    // The total amount of the underlying asset currently repaid from disbursed loans
     uint256 totalRepaid;
+    // The total amount of the underlying asset currently repaid in the form of interest owed from disbursed loans
     uint256 totalInterestRepaid;
+    // The decimals of the underlying ERC20 asset
     uint8 decimals;
+    // The status of token investment restriction
     bool restricted;
 }
 

--- a/contracts/lending/ttoken/strategies/compound/TTokenCompoundStrategy_1.sol
+++ b/contracts/lending/ttoken/strategies/compound/TTokenCompoundStrategy_1.sol
@@ -2,9 +2,7 @@
 pragma solidity ^0.8.0;
 
 // contracts
-import {
-    RolesMods
-} from "../../../../contexts2/access-control/roles/RolesMods.sol";
+import { RolesMods } from "../../../../contexts2/access-control/roles/RolesMods.sol";
 import { ADMIN } from "../../data.sol";
 
 // Interfaces
@@ -12,9 +10,7 @@ import { ICErc20 } from "../../../../shared/interfaces/ICErc20.sol";
 import { TTokenStrategy } from "../TTokenStrategy.sol";
 
 // Libraries
-import {
-    SafeERC20
-} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import { NumbersLib } from "../../../../shared/libraries/NumbersLib.sol";
 
 // Storage
@@ -56,15 +52,19 @@ contract TTokenCompoundStrategy_1 is RolesMods, TTokenStrategy {
      * (storedRatio > balanceRatioMax) or withdraw to keep the ratio within that range.
      */
     function rebalance() public override {
-        (uint256 storedBal, uint256 compoundBal, uint16 storedRatio) =
-            _getBalanceInfo();
+        (
+            uint256 storedBal,
+            uint256 compoundBal,
+            uint16 storedRatio
+        ) = _getBalanceInfo();
         if (storedRatio > compoundStore().balanceRatioMax) {
             // Calculate median ratio to rebalance to
-            uint16 medianRatio =
-                (compoundStore().balanceRatioMax +
-                    compoundStore().balanceRatioMin) / 2;
-            uint256 requiredBal =
-                NumbersLib.percent(storedBal + compoundBal, medianRatio);
+            uint16 medianRatio = (compoundStore().balanceRatioMax +
+                compoundStore().balanceRatioMin) / 2;
+            uint256 requiredBal = NumbersLib.percent(
+                storedBal + compoundBal,
+                medianRatio
+            );
             uint256 amountToDeposit = storedBal - requiredBal;
 
             // Allow Compound to take underlying tokens
@@ -93,8 +93,11 @@ contract TTokenCompoundStrategy_1 is RolesMods, TTokenStrategy {
      * @param amount Amount of underlying tokens that must be available.
      */
     function withdraw(uint256 amount) external override {
-        (uint256 storedBal, uint256 compoundBal, uint16 storedRatio) =
-            _getBalanceInfo();
+        (
+            uint256 storedBal,
+            uint256 compoundBal,
+            uint16 storedRatio
+        ) = _getBalanceInfo();
         if (storedBal < amount) {
             _withdraw(amount, storedBal, compoundBal, storedRatio);
         }
@@ -134,14 +137,12 @@ contract TTokenCompoundStrategy_1 is RolesMods, TTokenStrategy {
         uint16 storedRatio
     ) internal {
         // Calculate amount to rebalance
-        uint16 medianRatio =
-            (compoundStore().balanceRatioMax +
-                compoundStore().balanceRatioMin) / 2;
-        uint256 requiredBal =
-            NumbersLib.percent(
-                storedBal + compoundBal - amount,
-                medianRatio - storedRatio
-            );
+        uint16 medianRatio = (compoundStore().balanceRatioMax +
+            compoundStore().balanceRatioMin) / 2;
+        uint256 requiredBal = NumbersLib.percent(
+            storedBal + compoundBal - amount,
+            medianRatio - storedRatio
+        );
         uint256 redeemAmount = requiredBal - storedBal + amount;
         // Withdraw tokens from Compound if needed
         compoundStore().cToken.redeemUnderlying(redeemAmount);
@@ -152,6 +153,7 @@ contract TTokenCompoundStrategy_1 is RolesMods, TTokenStrategy {
      * @param cTokenAddress Address of the Compound token that has the same underlying asset as the TToken.
      * @param balanceRatioMin Percentage indicating the _ limit of underlying token balance should remain on the TToken
      * @param balanceRatioMax Percentage indicating the _ limit of underlying token balance should remain on the TToken
+     * @dev Note that the balanceRatio percentages have to be scaled by ONE_HUNDRED_PERCENT
      */
     function init(
         address cTokenAddress,


### PR DESCRIPTION
Adding missing docstrings to the following:
- tToken exchangeRate()
- tToken mint()
- Store struct of tToken storage.sol
- TTokenCompoundStrategy init()