### PR TITLE
[PROTOCOL-636] [M03] Lack of event emission after sensitive actions

### DIFF
--- a/contracts/lending/ttoken/ITToken.sol
+++ b/contracts/lending/ttoken/ITToken.sol
@@ -54,6 +54,13 @@ abstract contract ITToken is ERC20Upgradeable, RolesFacet {
     );
 
     /**
+     * @notice This event is emitted when a new investment management strategy has been set for a Teller token.
+     * @param strategyAddress The address of the new strategy set for managing the underlying assets held by the tToken.
+     * @param sender The address of the sender setting the token strategy.
+     */
+    event StrategySet(address strategyAddress, address indexed sender);
+
+    /**
      * @notice This event is emitted when the platform restriction is switched
      * @param restriction Boolean representing the state of the restriction
      * @param investmentManager address of the investment manager flipping the switch

--- a/contracts/lending/ttoken/ITToken.sol
+++ b/contracts/lending/ttoken/ITToken.sol
@@ -35,6 +35,25 @@ abstract contract ITToken is ERC20Upgradeable, RolesFacet {
     );
 
     /**
+     * @notice This event is emitted when a loan has been taken out through the Teller Diamond.
+     * @param recipient The address receiving the borrowed funds.
+     * @param totalBorrowed The total amount being loaned out by the tToken.
+     */
+    event LoanFunded(address indexed recipient, uint256 totalBorrowed);
+
+    /**
+     * @notice This event is emitted when a loan has been repaid through the Teller Diamond.
+     * @param sender The address making the payment to the tToken.
+     * @param principlePayment The amount paid back towards the principle loaned out by the tToken.
+     * @param interestPayment The amount paid back towards the interest owed to the tToken.
+     */
+    event LoanPaymentMade(
+        address indexed sender,
+        uint256 principlePayment,
+        uint256 interestPayment
+    );
+
+    /**
      * @notice This event is emitted when the platform restriction is switched
      * @param restriction Boolean representing the state of the restriction
      * @param investmentManager address of the investment manager flipping the switch

--- a/contracts/lending/ttoken/ITToken.sol
+++ b/contracts/lending/ttoken/ITToken.sol
@@ -35,6 +35,16 @@ abstract contract ITToken is ERC20Upgradeable, RolesFacet {
     );
 
     /**
+     * @notice This event is emitted when the platform restriction is switched
+     * @param restriction Boolean representing the state of the restriction
+     * @param investmentManager address of the investment manager flipping the switch
+     */
+    event PlatformRestricted(
+        bool restriction,
+        address indexed investmentManager
+    );
+
+    /**
      * @notice The token that is the underlying asset for this Teller token.
      * @return ERC20 token
      */

--- a/contracts/lending/ttoken/TToken_V1.sol
+++ b/contracts/lending/ttoken/TToken_V1.sol
@@ -358,6 +358,7 @@ contract TToken_V1 is ITToken {
         if (initData.length > 0) {
             _delegateStrategy(initData);
         }
+        emit StrategySet(strategy, _msgSender());
     }
 
     /**

--- a/contracts/lending/ttoken/TToken_V1.sol
+++ b/contracts/lending/ttoken/TToken_V1.sol
@@ -189,6 +189,7 @@ contract TToken_V1 is ITToken {
 
         // Transfer tokens to recipient
         SafeERC20.safeTransfer(s().underlying, recipient, amount);
+        emit LoanFunded(recipient, amount);
     }
 
     /**
@@ -203,6 +204,7 @@ contract TToken_V1 is ITToken {
     {
         s().totalRepaid += amount;
         s().totalInterestRepaid += interestAmount;
+        emit LoanPaymentMade(_msgSender(), amount, interestAmount);
     }
 
     /**

--- a/contracts/lending/ttoken/TToken_V1.sol
+++ b/contracts/lending/ttoken/TToken_V1.sol
@@ -367,7 +367,7 @@ contract TToken_V1 is ITToken {
     }
 
     /**
-     * @notice Sets the restricted state of the platform.
+     * @notice Sets the restricted state of the tToken.
      * @param state boolean value that resembles the platform's state
      */
     function restrict(bool state)
@@ -376,6 +376,7 @@ contract TToken_V1 is ITToken {
         authorized(ADMIN, _msgSender())
     {
         s().restricted = state;
+        emit PlatformRestricted(state, _msgSender());
     }
 
     /**

--- a/contracts/lending/ttoken/strategies/ITTokenStrategy.sol
+++ b/contracts/lending/ttoken/strategies/ITTokenStrategy.sol
@@ -2,8 +2,25 @@
 pragma solidity ^0.8.0;
 
 interface ITTokenStrategy {
+    /**
+     * @notice This event is emitted when the underlying assets are rebalanced as directed by the set investment strategy.
+     * @param strategyName The name of the strategy being rebalanced - example: "CompoundStrategy_1"
+     * @param sender The address of the sender rebalancing the token strategy.
+     */
     event StrategyRebalanced(
         string indexed strategyName,
+        address indexed sender
+    );
+
+    /**
+     * @notice This event is emitted when the underlying assets are rebalanced as directed by the set investment strategy.
+     * @param strategyName The name of the strategy being rebalanced - example: "CompoundStrategy_1"
+     * @param investmentAsset The address of the investible asset / protocol being used to leverage the underlying assets.
+     * @param sender The address of the sender rebalancing the token strategy.
+     */
+    event StrategyInitialized(
+        string indexed strategyName,
+        address investmentAsset,
         address indexed sender
     );
 
@@ -15,7 +32,6 @@ interface ITTokenStrategy {
 
     /**
      * @notice it rebalances the underlying asset held by the Teller Token.
-     *
      */
     function rebalance() external;
 

--- a/contracts/lending/ttoken/strategies/compound/TTokenCompoundStrategy_1.sol
+++ b/contracts/lending/ttoken/strategies/compound/TTokenCompoundStrategy_1.sol
@@ -16,6 +16,7 @@ import {
     SafeERC20
 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import { NumbersLib } from "../../../../shared/libraries/NumbersLib.sol";
+import { LibMeta } from "../../../../shared/libraries/LibMeta.sol";
 
 // Storage
 import "../../storage.sol" as TokenStorage;
@@ -160,5 +161,6 @@ contract TTokenCompoundStrategy_1 is RolesMods, TTokenStrategy {
         compoundStore().cToken = ICErc20(cTokenAddress);
         compoundStore().balanceRatioMin = balanceRatioMin;
         compoundStore().balanceRatioMax = balanceRatioMax;
+        emit StrategyInitialized(NAME, cTokenAddress, LibMeta.msgSender());
     }
 }


### PR DESCRIPTION
Dup of #423 using correct branch naming structure 

> Adding event emissions to the following relevant events:
> - The restrict function from the TToken_V1 contract.
> - The repayLoan function from the TToken_V1 contract when a loan has been repaid.
> - The fundLoan function from the TToken_V1 contract when a loan has been taken out.
> - The setStrategy function from the TToken_V1 contract.
> - The init function from the TTokenCompoundStrategy_1 contract when setting new parameters for the strategy.