### PR TITLE
[PROTOCOL-637] [L01] Missing docstrings

### DIFF
--- a/contracts/lending/ttoken/TToken_V1.sol
+++ b/contracts/lending/ttoken/TToken_V1.sol
@@ -81,8 +81,8 @@ contract TToken_V1 is ITToken {
     }
 
     /**
-     * @notice It calculates the current exchange rate for a whole Teller Token based off the underlying token balance.
-     * @return rate_ The current exchange rate.
+     * @notice It calculates the current scaled exchange rate for a whole Teller Token based of the underlying token balance.
+     * @return rate_ The current exchange rate, scaled by the EXCHANGE_RATE_FACTOR.
      */
     function exchangeRate() public override returns (uint256 rate_) {
         if (totalSupply() == 0) {
@@ -206,6 +206,7 @@ contract TToken_V1 is ITToken {
     }
 
     /**
+     * @dev The tToken contract needs to have been granted sufficient allowance to transfer the amount being used to mint.
      * @notice Deposit underlying token amount into LP and mint tokens.
      * @param amount The amount of underlying tokens to use to mint.
      * @return Amount of TTokens minted.

--- a/contracts/lending/ttoken/strategies/compound/TTokenCompoundStrategy_1.sol
+++ b/contracts/lending/ttoken/strategies/compound/TTokenCompoundStrategy_1.sol
@@ -147,6 +147,7 @@ contract TTokenCompoundStrategy_1 is RolesMods, TTokenStrategy {
      * @param cTokenAddress Address of the Compound token that has the same underlying asset as the TToken.
      * @param balanceRatioMin Percentage indicating the _ limit of underlying token balance should remain on the TToken
      * @param balanceRatioMax Percentage indicating the _ limit of underlying token balance should remain on the TToken
+     * @dev Note that the balanceRatio percentages have to be scaled by ONE_HUNDRED_PERCENT
      */
     function init(
         address cTokenAddress,

--- a/contracts/lending/ttoken/token-storage.sol
+++ b/contracts/lending/ttoken/token-storage.sol
@@ -4,12 +4,19 @@ pragma solidity ^0.8.0;
 import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 
 struct Store {
+    // The underlying asset of the tToken
     ERC20 underlying;
+    // The address of the investment strategy contract managing the underlying assets
     address strategy;
+    // The total amount of the underlying asset currently out in disbursed loans
     uint256 totalBorrowed;
+    // The total amount of the underlying asset currently repaid from disbursed loans
     uint256 totalRepaid;
+    // The total amount of the underlying asset currently repaid in the form of interest owed from disbursed loans
     uint256 totalInterestRepaid;
+    // The decimals of the underlying ERC20 asset
     uint8 decimals;
+    // The status of token investment restriction
     bool restricted;
 }
 


### PR DESCRIPTION
Duplicate of #425 using correct branch naming structure

> Adding missing docstrings to the following:
> - tToken exchangeRate()
> - tToken mint()
> - Store struct of tToken storage.sol
> - TTokenCompoundStrategy init()