### PR TITLE
unstake function

### DIFF
--- a/contracts/nft/NFTFacet.sol
+++ b/contracts/nft/NFTFacet.sol
@@ -10,9 +10,7 @@ import { ADMIN, AUTHORIZED } from "../shared/roles.sol";
 import "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
 import { NFTLib } from "./libraries/NFTLib.sol";
 import { RolesLib } from "../contexts2/access-control/roles/RolesLib.sol";
-import {
-    EnumerableSet
-} from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
+import { EnumerableSet } from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
 
 contract NFTFacet is RolesMods {
     /**
@@ -41,6 +39,19 @@ contract NFTFacet is RolesMods {
         loanNFTs = new uint256[](EnumerableSet.length(nfts));
         for (uint256 i; i < EnumerableSet.length(nfts); i++) {
             loanNFTs[i] = EnumerableSet.at(nfts, i);
+        }
+    }
+
+    /**
+     * @notice it unstakes the user's NFTs and transfers it from the diamond
+     * back to the user
+     * @param nftIDs the nftIDs to unstake
+     */
+    function unstakeNFTs(uint256[] calldata nftIDs) external {
+        for (uint256 i; i < nftIDs.length; i++) {
+            // Unstake NFTs
+            NFTLib.unstake(nftIDs[i]);
+            NFTLib.nft().transferFrom(address(this), msg.sender, nftIDs[i]);
         }
     }
 

--- a/contracts/nft/NFTFacet.sol
+++ b/contracts/nft/NFTFacet.sol
@@ -10,7 +10,9 @@ import { ADMIN, AUTHORIZED } from "../shared/roles.sol";
 import "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
 import { NFTLib } from "./libraries/NFTLib.sol";
 import { RolesLib } from "../contexts2/access-control/roles/RolesLib.sol";
-import { EnumerableSet } from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
+import {
+    EnumerableSet
+} from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
 
 contract NFTFacet is RolesMods {
     /**

--- a/contracts/nft/NFTFacet.sol
+++ b/contracts/nft/NFTFacet.sol
@@ -51,8 +51,12 @@ contract NFTFacet is RolesMods {
      */
     function unstakeNFTs(uint256[] calldata nftIDs) external {
         for (uint256 i; i < nftIDs.length; i++) {
-            // Unstake NFTs
-            NFTLib.unstake(nftIDs[i]);
+            // Unstake NFTs by requiring that removing of the staked NFTs by
+            // the msg.sender is a success. If it isn't, we revert
+            require(
+                NFTLib.unstake(nftIDs[i]),
+                "Teller: not the owner of the NFT ID!"
+            );
             NFTLib.nft().transferFrom(address(this), msg.sender, nftIDs[i]);
         }
     }

--- a/test/integration/loans.test.ts
+++ b/test/integration/loans.test.ts
@@ -14,9 +14,6 @@ import {
   takeOutLoanWithoutNfts,
 } from '../helpers/loans'
 
-chai.should()
-chai.use(solidity)
-
 const { getNamedSigner, contracts, tokens, ethers, evm, toBN } = hre
 
 describe('Loans', () => {

--- a/test/integration/nft.test.ts
+++ b/test/integration/nft.test.ts
@@ -1,0 +1,79 @@
+import chai, { expect } from 'chai'
+import { Console } from 'console'
+import { solidity } from 'ethereum-waffle'
+import { BigNumber, Signer } from 'ethers'
+import hre from 'hardhat'
+
+import { getMarkets, getNFT } from '../../config'
+import { claimNFT } from '../../tasks'
+import { Market } from '../../types/custom/config-types'
+import { ITellerDiamond, TellerNFT } from '../../types/typechain'
+import { fundedMarket } from '../fixtures'
+import {
+  LoanType,
+  takeOutLoanWithNfts,
+  takeOutLoanWithoutNfts,
+} from '../helpers/loans'
+
+chai.should()
+chai.use(solidity)
+
+const { getNamedSigner, contracts, tokens, ethers, evm, toBN } = hre
+
+describe('NFT tests', () => {
+  let deployer: Signer
+  let diamond: ITellerDiamond
+  let borrowerSigner: Signer
+  let borrower: string
+  let ownedNFTs: BigNumber[]
+  let stakedNFTs: BigNumber[]
+  let rootToken: TellerNFT
+
+  before(async () => {
+    // addresses
+    deployer = await getNamedSigner('deployer')
+    borrower = '0x86a41524cb61edd8b115a72ad9735f8068996688'
+    borrowerSigner = (await hre.evm.impersonate(borrower)).signer
+
+    // diamond and teller nft
+    diamond = await contracts.get('TellerDiamond')
+    rootToken = await contracts.get('TellerNFT')
+
+    // claim nft on behalf of the borrower
+    await claimNFT({ account: borrower, merkleIndex: 0 }, hre)
+
+    // get borrower's owned nfts
+    ownedNFTs = await rootToken
+      .getOwnedTokens(borrower)
+      .then((arr) => (arr.length > 2 ? arr.slice(0, 2) : arr))
+
+    // approve transfering NFTs from the borrower to the diamond address
+    await rootToken
+      .connect(borrowerSigner)
+      .setApprovalForAll(diamond.address, true)
+  })
+  describe.only('unstakes NFTs after staking them', () => {
+    it('should stake NFTs', async () => {
+      // stake NFTs on behalf of user
+      await diamond.connect(borrowerSigner).stakeNFTs(ownedNFTs)
+
+      // get staked
+      stakedNFTs = await diamond.getStakedNFTs(borrower)
+
+      // every tokenId of the owned NFT should equate a token ID from the stakedNFT
+      for (let i = 0; i < ownedNFTs.length; i++) {
+        expect(ownedNFTs[i]).to.equal(stakedNFTs[i])
+      }
+    })
+    it('should unstake NFTs', async () => {
+      // unstake all of our staked NFTs
+      await diamond.connect(borrowerSigner).unstakeNFTs(stakedNFTs)
+
+      // retrieve our staked NFTs (should be empty)
+      stakedNFTs = await diamond.getStakedNFTs(borrower)
+
+      // we expect our staked NFTs length to be 0
+      expect(stakedNFTs.length).to.equal(0)
+    })
+  })
+})

--- a/test/integration/nft.test.ts
+++ b/test/integration/nft.test.ts
@@ -76,4 +76,23 @@ describe('NFT tests', () => {
       expect(stakedNFTs.length).to.equal(0)
     })
   })
+  describe('unstakes NFTs from the wrong address', () => {
+    it('should stake NFTs', async () => {
+      // stake NFTs on behalf of user
+      await diamond.connect(borrowerSigner).stakeNFTs(ownedNFTs)
+
+      // get staked
+      stakedNFTs = await diamond.getStakedNFTs(borrower)
+
+      // every tokenId of the owned NFT should equate a token ID from the stakedNFT
+      for (let i = 0; i < ownedNFTs.length; i++) {
+        expect(ownedNFTs[i]).to.equal(stakedNFTs[i])
+      }
+  })
+  it("should unstake NFTs from the wrong address and fail", async () => {
+    // unstake all of our staked nfts from the wrong address
+    const tx = await diamond.connect(deployer).unstakeNFTs(stakedNFTs)
+    await tx.should.be.revertedWith('Teller: not the owner of the NFT ID!')
+  })
+})
 })

--- a/test/integration/nft.test.ts
+++ b/test/integration/nft.test.ts
@@ -20,7 +20,7 @@ chai.use(solidity)
 
 const { getNamedSigner, contracts, tokens, ethers, evm, toBN } = hre
 
-describe.only('NFT tests', () => {
+describe('NFT tests', () => {
   let deployer: Signer
   let diamond: ITellerDiamond
   let borrowerSigner: Signer

--- a/test/integration/nft.test.ts
+++ b/test/integration/nft.test.ts
@@ -20,7 +20,7 @@ chai.use(solidity)
 
 const { getNamedSigner, contracts, tokens, ethers, evm, toBN } = hre
 
-describe('NFT tests', () => {
+describe.only('NFT tests', () => {
   let deployer: Signer
   let diamond: ITellerDiamond
   let borrowerSigner: Signer
@@ -88,11 +88,13 @@ describe('NFT tests', () => {
       for (let i = 0; i < ownedNFTs.length; i++) {
         expect(ownedNFTs[i]).to.equal(stakedNFTs[i])
       }
+    })
+    it('should unstake NFTs from the wrong address and fail', async () => {
+      // unstake all of our staked nfts from the wrong address
+      await diamond
+        .connect(deployer)
+        .unstakeNFTs(stakedNFTs)
+        .should.be.revertedWith('Teller: not the owner of the NFT ID!')
+    })
   })
-  it("should unstake NFTs from the wrong address and fail", async () => {
-    // unstake all of our staked nfts from the wrong address
-    const tx = await diamond.connect(deployer).unstakeNFTs(stakedNFTs)
-    await tx.should.be.revertedWith('Teller: not the owner of the NFT ID!')
-  })
-})
 })

--- a/test/integration/nft.test.ts
+++ b/test/integration/nft.test.ts
@@ -52,7 +52,7 @@ describe('NFT tests', () => {
       .connect(borrowerSigner)
       .setApprovalForAll(diamond.address, true)
   })
-  describe.only('unstakes NFTs after staking them', () => {
+  describe('unstakes NFTs after staking them', () => {
     it('should stake NFTs', async () => {
       // stake NFTs on behalf of user
       await diamond.connect(borrowerSigner).stakeNFTs(ownedNFTs)


### PR DESCRIPTION
The Unstake function is an option for the user to unstake their NFTs on either Polygon or ETH MAINNET. This happens by removing them from the staked mapping then transferring to the users' respective wallets