### PR TITLE
Fix NFT loan interest 

### DIFF
--- a/contracts/market/libraries/LibLoans.sol
+++ b/contracts/market/libraries/LibLoans.sol
@@ -201,13 +201,16 @@ library LibLoans {
         view
         returns (uint16 ratio_)
     {
-        ratio_ = uint16(
-            (uint64(loan(loanID).duration) * loan(loanID).interestRate) /
-                SECONDS_PER_YEAR
-        );
+        if (loan(loanID).interestRate > 0) {
+            ratio_ = uint16(
+                (uint64(loan(loanID).duration) * loan(loanID).interestRate) /
+                    SECONDS_PER_YEAR
+            );
 
-        if (ratio_ == 0) {
-            ratio_ = 1;
+            // If calculation for interest ratio chopped off decimals resulting in 0%, set minimum interest to 1%
+            if (ratio_ == 0) {
+                ratio_ = 1;
+            }
         }
     }
 }

--- a/deploy/protocol.ts
+++ b/deploy/protocol.ts
@@ -75,23 +75,23 @@ const deployProtocol: DeployFunction = async (hre) => {
     // Settings
     {
       contract: 'SettingsFacet',
-      skipIfAlreadyDeployed: false,
+      skipIfAlreadyDeployed: true,
     },
     {
       contract: 'PlatformSettingsFacet',
-      skipIfAlreadyDeployed: false,
+      skipIfAlreadyDeployed: true,
     },
     {
       contract: 'AssetSettingsDataFacet',
-      skipIfAlreadyDeployed: false,
+      skipIfAlreadyDeployed: true,
     },
     {
       contract: 'AssetSettingsFacet',
-      skipIfAlreadyDeployed: false,
+      skipIfAlreadyDeployed: true,
     },
     {
       contract: 'PausableFacet',
-      skipIfAlreadyDeployed: false,
+      skipIfAlreadyDeployed: true,
     },
     // Pricing
     {
@@ -101,7 +101,7 @@ const deployProtocol: DeployFunction = async (hre) => {
     // Lending
     {
       contract: 'LendingFacet',
-      skipIfAlreadyDeployed: false,
+      skipIfAlreadyDeployed: true,
     },
     // Loans
     {
@@ -122,7 +122,7 @@ const deployProtocol: DeployFunction = async (hre) => {
     },
     {
       contract: 'SignersFacet',
-      skipIfAlreadyDeployed: false,
+      skipIfAlreadyDeployed: true,
     },
     // Dapps
     {


### PR DESCRIPTION
Loans with an NFT were given a default minimum interest ratio of 1%. The should only have a minimum of 1% if the interest rate defined on the loan was already > 0.