### PR TITLE
[PROTOCOL-717]  Create diamond extensions for Mainnet and Polygon networks

### DIFF
--- a/contracts/shared/interfaces/IMainnetDiamond.sol
+++ b/contracts/shared/interfaces/IMainnetDiamond.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import { ITellerDiamond } from "./ITellerDiamond.sol";
+import { MainnetNFTFacet } from "../../nft/mainnet/MainnetNFTFacet.sol";
+import {
+    NFTMainnetBridgingToPolygonFacet
+} from "../../nft/mainnet/NFTMainnetBridgingToPolygonFacet.sol";
+
+abstract contract IMainnetDiamond is
+    ITellerDiamond,
+    MainnetNFTFacet,
+    NFTMainnetBridgingToPolygonFacet
+{}

--- a/contracts/shared/interfaces/IPolygonDiamond.sol
+++ b/contracts/shared/interfaces/IPolygonDiamond.sol
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import { ITellerDiamond } from "./ITellerDiamond.sol";
+import { NFTFacet } from "../../nft/NFTFacet.sol";
+
+abstract contract IPolyDiamond is ITellerDiamond, NFTFacet {}

--- a/contracts/shared/interfaces/ITellerDiamond.sol
+++ b/contracts/shared/interfaces/ITellerDiamond.sol
@@ -20,10 +20,10 @@ import { CreateLoanFacet } from "../../market/CreateLoanFacet.sol";
 import { LoanDataFacet } from "../../market/LoanDataFacet.sol";
 import { RepayFacet } from "../../market/RepayFacet.sol";
 import { SignersFacet } from "../../market/SignersFacet.sol";
-import { NFTFacet } from "../../nft/NFTFacet.sol";
-import {
-    NFTMainnetBridgingToPolygonFacet
-} from "../../nft/mainnet/NFTMainnetBridgingToPolygonFacet.sol";
+// import { NFTFacet } from "../../nft/NFTFacet.sol";
+// import {
+//     NFTMainnetBridgingToPolygonFacet
+// } from "../../nft/mainnet/NFTMainnetBridgingToPolygonFacet.sol";
 import { CollateralFacet } from "../../market/CollateralFacet.sol";
 import { CompoundFacet } from "../../escrow/dapps/CompoundFacet.sol";
 import {
@@ -44,8 +44,6 @@ abstract contract ITellerDiamond is
     LoanDataFacet,
     RepayFacet,
     SignersFacet,
-    NFTFacet,
-    NFTMainnetBridgingToPolygonFacet,
     CompoundFacet,
     CompoundClaimCompFacet,
     AaveFacet,

--- a/contracts/shared/interfaces/ITellerDiamond.sol
+++ b/contracts/shared/interfaces/ITellerDiamond.sol
@@ -20,10 +20,6 @@ import { CreateLoanFacet } from "../../market/CreateLoanFacet.sol";
 import { LoanDataFacet } from "../../market/LoanDataFacet.sol";
 import { RepayFacet } from "../../market/RepayFacet.sol";
 import { SignersFacet } from "../../market/SignersFacet.sol";
-// import { NFTFacet } from "../../nft/NFTFacet.sol";
-// import {
-//     NFTMainnetBridgingToPolygonFacet
-// } from "../../nft/mainnet/NFTMainnetBridgingToPolygonFacet.sol";
 import { CollateralFacet } from "../../market/CollateralFacet.sol";
 import { CompoundFacet } from "../../escrow/dapps/CompoundFacet.sol";
 import {


### PR DESCRIPTION
Two extended interfaces `IMainnetDiamond` and `IPolygonDiamond` are created which:
- Extend from the `ITellerDiamond`
- Extend their respective facets
