### PR TITLE
Set Tenderly project config based on network being used

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -99,7 +99,7 @@ export default <HardhatUserConfig>{
   },
   tenderly: {
     username: 'soltel',
-    project: 'mumbai',
+    project: '{see utils/hre-extensions.ts}',
   },
   paths: {
     sources: 'contracts',

--- a/utils/hre-extensions.ts
+++ b/utils/hre-extensions.ts
@@ -10,6 +10,7 @@ import {
   utils,
 } from 'ethers'
 import { extendEnvironment, subtask } from 'hardhat/config'
+import { HardhatRuntimeEnvironment } from 'hardhat/types'
 import moment from 'moment'
 
 import { getTokens } from '../config'
@@ -125,8 +126,38 @@ interface AddressObj {
   [name: string]: Address | AddressObj
 }
 
+/**
+ * Updates the Tenderly project name in the config based on the network being
+ *  used.
+ * @param hre {HardhatRuntimeEnvironment} Hardhat Environment variable to modify
+ *  directly
+ */
+const updateTenderlyConfig = (hre: HardhatRuntimeEnvironment): void => {
+  let projectName: string
+  switch (hre.network.name) {
+    case 'mainnet':
+      projectName = 'teller'
+      break
+
+    case 'kovan':
+      projectName = 'kovan'
+      break
+
+    case 'mumbai':
+      projectName = 'mumbai'
+      break
+
+    default:
+      projectName = 'test'
+  }
+
+  hre.config.tenderly.project = projectName
+}
+
 extendEnvironment((hre) => {
   const { deployments, ethers, network } = hre
+
+  updateTenderlyConfig(hre)
 
   hre.contracts = {
     async get<C extends Contract>(


### PR DESCRIPTION
* Extends the `HRE` object to set the Tenderly project name based on the network being used by Hardhat