### PR TITLE
Add scripts to use future commits

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,9 @@
     "build": "yarn compile && yarn types && yarn tsc",
     "types": "yarn typechain --target ethers-v5 --out-dir types/typechain 'artifacts/!(build-info)/**/+([a-zA-Z0-9_]).json'",
     "coverage": "#yarn hh coverage --solcoverjs ./solcover.js",
-    "git": "func() { git add . && git commit -m \"$1\" && git push origin HEAD; }; func"
+    "git": "func() { git add . && git commit -m \"$1\" && git push origin HEAD; }; func",
+    "git:future": "./scripts/git/future.sh",
+    "git:portal": "./scripts/git/portal.sh"
   },
   "dependencies": {
     "@chainlink/contracts": "^0.1.6",

--- a/scripts/git/future.sh
+++ b/scripts/git/future.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+futureBranch=${1:-$(git branch --show-current)};
+featureBranch=$2;
+
+git checkout develop --detach;
+git merge --no-ff -m "future! $futureBranch" "$futureBranch" && (
+  git tag -f future/"$futureBranch";
+  test "$featureBranch" && (
+    git checkout -b "$featureBranch" ||
+      portal.sh "$futureBranch" "$featureBranch";
+  )
+)

--- a/scripts/git/portal.sh
+++ b/scripts/git/portal.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+futureBranch=$1;
+featureBranch=${2:-$(git branch --show-current)};
+
+test "$featureBranch" && (
+  # shellcheck disable=SC1083
+  git rev-parse "$featureBranch^{/future! $futureBranch}" &> /dev/null && (
+    git rebase --onto "future/$futureBranch" "$featureBranch^{/future! $futureBranch}" "$featureBranch";
+  ) || (
+    git rebase "future/$futureBranch" "$featureBranch";
+  )
+) || (
+  echo "Cannot omit feature branch while in detached HEAD"
+  echo
+  printf "\t Usage: git portal %s <feature-branch>" "$futureBranch"
+  exit 1;
+)


### PR DESCRIPTION
* Adds bash scripts, accessible via `package.json` scripts, that enables easy use for rebasing branches and rewriting the git history
* See [this Notion doc](https://www.notion.so/Future-Commits-1c928785e01247c5b16aef2b7196c431) for more details