### PR TITLE
[PROTOCOL-954] Take Out Loan V3

### DIFF
--- a/contracts/escrow/dapps/CompoundClaimComp.sol
+++ b/contracts/escrow/dapps/CompoundClaimComp.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.0;
 // Contracts
 import { DappMods } from "./DappMods.sol";
 import { PausableMods } from "../../settings/pausable/PausableMods.sol";
-import "hardhat/console.sol";
+
 // Libraries
 import { LibCompound } from "./libraries/LibCompound.sol";
 import { LibEscrow } from "../libraries/LibEscrow.sol";

--- a/contracts/market/CreateLoanWithNFTFacet.sol
+++ b/contracts/market/CreateLoanWithNFTFacet.sol
@@ -125,11 +125,12 @@ contract CreateLoanWithNFTFacet is ReentryMods, PausableMods {
         uint16 version,
         bytes memory tokenData
     ) internal virtual returns (uint256 allowedLoanSize_) {
-        if (version == 2) {
-            (uint256[] memory nftIDs, uint256[] memory amounts) = abi.decode(
-                tokenData,
-                (uint256[], uint256[])
-            );
+        if ((2 & version) == 2) {
+            (
+                uint256[] memory nftIDsV1,
+                uint256[] memory nftIDs,
+                uint256[] memory amounts
+            ) = abi.decode(tokenData, (uint256[], uint256[], uint256[]));
             for (uint256 i; i < nftIDs.length; i++) {
                 NFTLib.applyToLoanV2(loanID, nftIDs[i], amounts[i], msg.sender);
 
@@ -139,26 +140,5 @@ contract CreateLoanWithNFTFacet is ReentryMods, PausableMods {
                 allowedLoanSize_ += baseLoanSize * amounts[i];
             }
         }
-        //  else if (version == 3) {
-        //     // we only need the nftV2IDs and the nftV2amounts here
-        //     (
-        //         uint256[] memory nftV1IDs,
-        //         uint256[] memory nftV2IDs,
-        //         uint256[] memory nftV2amounts
-        //     ) = abi.decode(tokenData, (uint256[], uint256[], uint256[]));
-        //     for (uint256 i; i < nftV2IDs.length; i++) {
-        //         NFTLib.applyToLoanV2(
-        //             loanID,
-        //             nftV2IDs[i],
-        //             nftV2amounts[i],
-        //             msg.sender
-        //         );
-
-        //         uint256 baseLoanSize = TELLER_NFT_V2.tokenBaseLoanSize(
-        //             nftV2IDs[i]
-        //         );
-        //         allowedLoanSize_ += baseLoanSize * nftV2amounts[i];
-        //     }
-        // }
     }
 }

--- a/contracts/market/CreateLoanWithNFTFacet.sol
+++ b/contracts/market/CreateLoanWithNFTFacet.sol
@@ -125,12 +125,20 @@ contract CreateLoanWithNFTFacet is ReentryMods, PausableMods {
         uint16 version,
         bytes memory tokenData
     ) internal virtual returns (uint256 allowedLoanSize_) {
-        if ((2 & version) == 2) {
-            (
-                uint256[] memory nftIDsV1,
-                uint256[] memory nftIDs,
-                uint256[] memory amounts
-            ) = abi.decode(tokenData, (uint256[], uint256[], uint256[]));
+        bool useV2;
+        uint256[] memory nftIDs;
+        uint256[] memory amounts;
+        if (version == 2) {
+            (nftIDs, amounts) = abi.decode(tokenData, (uint256[], uint256[]));
+            useV2 = true;
+        } else if ((2 & version) == 2) {
+            (, nftIDs, amounts) = abi.decode(
+                tokenData,
+                (uint256[], uint256[], uint256[])
+            );
+            useV2 = true;
+        }
+        if (useV2) {
             for (uint256 i; i < nftIDs.length; i++) {
                 NFTLib.applyToLoanV2(loanID, nftIDs[i], amounts[i], msg.sender);
 

--- a/contracts/market/CreateLoanWithNFTFacet.sol
+++ b/contracts/market/CreateLoanWithNFTFacet.sol
@@ -115,6 +115,23 @@ contract CreateLoanWithNFTFacet is ReentryMods, PausableMods {
                     version,
                     tokenData_
                 );
+        } else if (version == 3) {
+            // get loan size from first function
+            uint256 loanSize1 = CreateLoanWithNFTFacet._takeOutLoanProcessNFTs(
+                loanID,
+                version,
+                tokenData_
+            );
+
+            // get loan size from second function
+            uint256 loanSize2 = _takeOutLoanProcessNFTs(
+                loanID,
+                version,
+                tokenData_
+            );
+
+            // add both and return the calculated loan size
+            return loanSize1 + loanSize2;
         } else {
             return _takeOutLoanProcessNFTs(loanID, version, tokenData_);
         }
@@ -145,6 +162,26 @@ contract CreateLoanWithNFTFacet is ReentryMods, PausableMods {
                     nftIDs[i]
                 );
                 allowedLoanSize_ += baseLoanSize * amounts[i];
+            }
+        } else if (version == 3) {
+            // we only need the nftV2IDs and the nftV2amounts here
+            (
+                uint256[] memory nftV1IDs,
+                uint256[] memory nftV2IDs,
+                uint256[] memory nftV2amounts
+            ) = abi.decode(tokenData, (uint256[], uint256[], uint256[]));
+            for (uint256 i; i < nftV2IDs.length; i++) {
+                NFTLib.applyToLoanV2(
+                    loanID,
+                    nftV2IDs[i],
+                    nftV2amounts[i],
+                    msg.sender
+                );
+
+                uint256 baseLoanSize = TELLER_NFT_V2.tokenBaseLoanSize(
+                    nftV2IDs[i]
+                );
+                allowedLoanSize_ += baseLoanSize * nftV2amounts[i];
             }
         }
     }

--- a/contracts/market/CreateLoanWithNFTFacet.sol
+++ b/contracts/market/CreateLoanWithNFTFacet.sol
@@ -108,33 +108,8 @@ contract CreateLoanWithNFTFacet is ReentryMods, PausableMods {
             tokenData,
             (uint8, bytes)
         );
-        if (version == 2) {
-            return
-                CreateLoanWithNFTFacet._takeOutLoanProcessNFTs(
-                    loanID,
-                    version,
-                    tokenData_
-                );
-        } else if (version == 3) {
-            // get loan size from first function
-            uint256 loanSize1 = CreateLoanWithNFTFacet._takeOutLoanProcessNFTs(
-                loanID,
-                version,
-                tokenData_
-            );
 
-            // get loan size from second function
-            uint256 loanSize2 = _takeOutLoanProcessNFTs(
-                loanID,
-                version,
-                tokenData_
-            );
-
-            // add both and return the calculated loan size
-            return loanSize1 + loanSize2;
-        } else {
-            return _takeOutLoanProcessNFTs(loanID, version, tokenData_);
-        }
+        return _takeOutLoanProcessNFTs(loanID, version, tokenData_);
     }
 
     /**
@@ -163,26 +138,27 @@ contract CreateLoanWithNFTFacet is ReentryMods, PausableMods {
                 );
                 allowedLoanSize_ += baseLoanSize * amounts[i];
             }
-        } else if (version == 3) {
-            // we only need the nftV2IDs and the nftV2amounts here
-            (
-                uint256[] memory nftV1IDs,
-                uint256[] memory nftV2IDs,
-                uint256[] memory nftV2amounts
-            ) = abi.decode(tokenData, (uint256[], uint256[], uint256[]));
-            for (uint256 i; i < nftV2IDs.length; i++) {
-                NFTLib.applyToLoanV2(
-                    loanID,
-                    nftV2IDs[i],
-                    nftV2amounts[i],
-                    msg.sender
-                );
-
-                uint256 baseLoanSize = TELLER_NFT_V2.tokenBaseLoanSize(
-                    nftV2IDs[i]
-                );
-                allowedLoanSize_ += baseLoanSize * nftV2amounts[i];
-            }
         }
+        //  else if (version == 3) {
+        //     // we only need the nftV2IDs and the nftV2amounts here
+        //     (
+        //         uint256[] memory nftV1IDs,
+        //         uint256[] memory nftV2IDs,
+        //         uint256[] memory nftV2amounts
+        //     ) = abi.decode(tokenData, (uint256[], uint256[], uint256[]));
+        //     for (uint256 i; i < nftV2IDs.length; i++) {
+        //         NFTLib.applyToLoanV2(
+        //             loanID,
+        //             nftV2IDs[i],
+        //             nftV2amounts[i],
+        //             msg.sender
+        //         );
+
+        //         uint256 baseLoanSize = TELLER_NFT_V2.tokenBaseLoanSize(
+        //             nftV2IDs[i]
+        //         );
+        //         allowedLoanSize_ += baseLoanSize * nftV2amounts[i];
+        //     }
+        // }
     }
 }

--- a/contracts/market/mainnet/MainnetCreateLoanWithNFTFacet.sol
+++ b/contracts/market/mainnet/MainnetCreateLoanWithNFTFacet.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.0;
 
 // Contracts
 import { CreateLoanWithNFTFacet } from "../CreateLoanWithNFTFacet.sol";
+import { TellerNFT_V2 } from "../../nft/TellerNFT_V2.sol";
 
 // Libraries
 import { NFTLib } from "../../nft/libraries/NFTLib.sol";
@@ -25,35 +26,33 @@ contract MainnetCreateLoanWithNFTFacet is CreateLoanWithNFTFacet {
         uint16 version,
         bytes memory tokenData
     ) internal virtual override returns (uint256 allowedLoanSize_) {
-        if (version == 1) {
+        uint256 v1Amount;
+        uint256 v2Amount;
+        if ((1 & version) == 1) {
             uint256[] memory nftIDs = abi.decode(tokenData, (uint256[]));
             for (uint256 i; i < nftIDs.length; i++) {
                 NFTLib.applyToLoan(loanID, nftIDs[i], msg.sender);
 
+                // add to allowedLoanSize
                 allowedLoanSize_ += NFTLib.s().nftDictionary.tokenBaseLoanSize(
                     nftIDs[i]
                 );
+                v1Amount += allowedLoanSize_;
             }
-        } else if (version == 3) {
-            // we only need the NFTV1IDs here
-            (
-                uint256[] memory nftV1IDs,
-                uint256[] memory nftV2IDs,
-                uint256[] memory nftV2amounts
-            ) = abi.decode(tokenData, (uint256[], uint256[], uint256[]));
-            for (uint256 i; i < nftV1IDs.length; i++) {
-                NFTLib.applyToLoan(loanID, nftV1IDs[i], msg.sender);
-
-                allowedLoanSize_ += NFTLib.s().nftDictionary.tokenBaseLoanSize(
-                    nftV1IDs[i]
-                );
-            }
-        } else {
+        }
+        if ((2 & version) == 2) {
             allowedLoanSize_ = super._takeOutLoanProcessNFTs(
                 loanID,
                 version,
                 tokenData
             );
+            v2Amount = allowedLoanSize_;
+        }
+
+        if (((1 & version) == 1) && ((2 & version) == 2)) {
+            // given that it's both version 1 and 2, then we overwrite the allowedLoanSize_
+            // variable and add both v1Amount and v2Amount
+            allowedLoanSize_ = v1Amount + v2Amount;
         }
     }
 }

--- a/contracts/market/mainnet/MainnetCreateLoanWithNFTFacet.sol
+++ b/contracts/market/mainnet/MainnetCreateLoanWithNFTFacet.sol
@@ -34,6 +34,20 @@ contract MainnetCreateLoanWithNFTFacet is CreateLoanWithNFTFacet {
                     nftIDs[i]
                 );
             }
+        } else if (version == 3) {
+            // we only need the NFTV1IDs here
+            (
+                uint256[] memory nftV1IDs,
+                uint256[] memory nftV2IDs,
+                uint256[] memory nftV2amounts
+            ) = abi.decode(tokenData, (uint256[], uint256[], uint256[]));
+            for (uint256 i; i < nftV1IDs.length; i++) {
+                NFTLib.applyToLoan(loanID, nftV1IDs[i], msg.sender);
+
+                allowedLoanSize_ += NFTLib.s().nftDictionary.tokenBaseLoanSize(
+                    nftV1IDs[i]
+                );
+            }
         } else {
             allowedLoanSize_ = super._takeOutLoanProcessNFTs(
                 loanID,

--- a/contracts/market/mainnet/MainnetCreateLoanWithNFTFacet.sol
+++ b/contracts/market/mainnet/MainnetCreateLoanWithNFTFacet.sol
@@ -50,8 +50,6 @@ contract MainnetCreateLoanWithNFTFacet is CreateLoanWithNFTFacet {
         }
 
         if (((1 & version) == 1) && ((2 & version) == 2)) {
-            // given that it's both version 1 and 2, then we overwrite the allowedLoanSize_
-            // variable and add both v1Amount and v2Amount
             allowedLoanSize_ = v1Amount + v2Amount;
         }
     }

--- a/contracts/market/mainnet/MainnetCreateLoanWithNFTFacet.sol
+++ b/contracts/market/mainnet/MainnetCreateLoanWithNFTFacet.sol
@@ -27,7 +27,6 @@ contract MainnetCreateLoanWithNFTFacet is CreateLoanWithNFTFacet {
         bytes memory tokenData
     ) internal virtual override returns (uint256 allowedLoanSize_) {
         uint256 v1Amount;
-        uint256 v2Amount;
         if ((1 & version) == 1) {
             uint256[] memory nftIDs = abi.decode(tokenData, (uint256[]));
             for (uint256 i; i < nftIDs.length; i++) {
@@ -40,17 +39,8 @@ contract MainnetCreateLoanWithNFTFacet is CreateLoanWithNFTFacet {
                 v1Amount += allowedLoanSize_;
             }
         }
-        if ((2 & version) == 2) {
-            allowedLoanSize_ = super._takeOutLoanProcessNFTs(
-                loanID,
-                version,
-                tokenData
-            );
-            v2Amount = allowedLoanSize_;
-        }
-
-        if (((1 & version) == 1) && ((2 & version) == 2)) {
-            allowedLoanSize_ = v1Amount + v2Amount;
-        }
+        allowedLoanSize_ =
+            super._takeOutLoanProcessNFTs(loanID, version, tokenData) +
+            v1Amount;
     }
 }

--- a/test/helpers/loans.ts
+++ b/test/helpers/loans.ts
@@ -344,7 +344,13 @@ export const takeOutLoanWithNfts = async (
       // Encode the NFT V1 token data for the function
       const tokenData = coder.encode(
         ['uint16', 'bytes'],
-        [1, coder.encode(['uint256[]'], [nftsUsed.v1])]
+        [
+          1,
+          coder.encode(
+            ['uint256[]', 'uint256[]', 'uint256[]'],
+            [nftsUsed.v1, [], []]
+          ),
+        ]
       )
 
       // plug it in the takeOutLoanWithNFTs function
@@ -385,11 +391,10 @@ export const takeOutLoanWithNfts = async (
       // get all the borrower's NFTs
       const ownedNFTs = await nft.getOwnedTokens(borrowerAddress)
 
-      // // Set NFT approval
-      // await nft.connect(borrower).setApprovalForAll(diamond.address, true)
+      // Set NFT approval
+      await nft.connect(borrower).setApprovalForAll(diamond.address, true)
       //
       // // Stake NFTs by transferring from the msg.sender (borrower) to the diamond
-      // await diamond.connect(borrower).mockStakeNFTsV1(ownedNFTs)
       nftsUsed.v2 = mergeV2IDsToBalances(ownedNFTs)
       await nft
         .connect(borrower)
@@ -400,15 +405,14 @@ export const takeOutLoanWithNfts = async (
           nftsUsed.v2.balances,
           '0x'
         )
-
       // Encode the NFT V2 token data for the function
       const tokenData = coder.encode(
         ['uint16', 'bytes'],
         [
           2,
           coder.encode(
-            ['uint256[]', 'uint256[]'],
-            [nftsUsed.v2.ids, nftsUsed.v2.balances]
+            ['uint256[]', 'uint256[]', 'uint256[]'],
+            [[], nftsUsed.v2.ids, nftsUsed.v2.balances]
           ),
         ]
       )
@@ -442,13 +446,13 @@ export const takeOutLoanWithNfts = async (
         hre,
       })
       await mintNFTV2({
-        tierIndex: 2,
+        tierIndex: 1,
         amount: 2,
         borrower: borrowerAddress,
         hre,
       })
       await mintNFTV2({
-        tierIndex: 3,
+        tierIndex: 2,
         amount: 2,
         borrower: borrowerAddress,
         hre,
@@ -457,12 +461,15 @@ export const takeOutLoanWithNfts = async (
       // get all the borrower's NFTs V1
       nftsUsed.v1 = await nft.getOwnedTokens(borrowerAddress)
 
+      // set nft approval
+      await nft.connect(borrower).setApprovalForAll(diamond.address, true)
+
       // get all the borrower's NFTs V2
       const ownedNFTs = await nftV2.getOwnedTokens(borrowerAddress)
+      await nftV2.connect(borrower).setApprovalForAll(diamond.address, true)
       nftsUsed.v2 = mergeV2IDsToBalances(ownedNFTs)
 
       // Set NFT approval
-      await nft.connect(borrower).setApprovalForAll(diamond.address, true)
 
       // Stake NFTs by transferring from the msg.sender (borrower) to the diamond
       await (diamond as any as MainnetNFTFacetMock)
@@ -478,8 +485,6 @@ export const takeOutLoanWithNfts = async (
           nftsUsed.v2.balances,
           '0x'
         )
-      console.log('loans.ts: nfts used v2')
-      console.log(nftsUsed.v2)
       // Encode the NFT V1 token data for the function
       const tokenData = coder.encode(
         ['uint16', 'bytes'],

--- a/test/helpers/loans.ts
+++ b/test/helpers/loans.ts
@@ -344,13 +344,7 @@ export const takeOutLoanWithNfts = async (
       // Encode the NFT V1 token data for the function
       const tokenData = coder.encode(
         ['uint16', 'bytes'],
-        [
-          1,
-          coder.encode(
-            ['uint256[]', 'uint256[]', 'uint256[]'],
-            [nftsUsed.v1, [], []]
-          ),
-        ]
+        [1, coder.encode(['uint256[]'], [nftsUsed.v1])]
       )
 
       // plug it in the takeOutLoanWithNFTs function
@@ -411,8 +405,8 @@ export const takeOutLoanWithNfts = async (
         [
           2,
           coder.encode(
-            ['uint256[]', 'uint256[]', 'uint256[]'],
-            [[], nftsUsed.v2.ids, nftsUsed.v2.balances]
+            ['uint256[]', 'uint256[]'],
+            [nftsUsed.v2.ids, nftsUsed.v2.balances]
           ),
         ]
       )

--- a/test/helpers/loans.ts
+++ b/test/helpers/loans.ts
@@ -478,7 +478,8 @@ export const takeOutLoanWithNfts = async (
           nftsUsed.v2.balances,
           '0x'
         )
-
+      console.log('loans.ts: nfts used v2')
+      console.log(nftsUsed.v2)
       // Encode the NFT V1 token data for the function
       const tokenData = coder.encode(
         ['uint16', 'bytes'],

--- a/test/integration/loans.test.ts
+++ b/test/integration/loans.test.ts
@@ -298,6 +298,43 @@ describe('Loans', () => {
               expect(loanData.status).to.equal(LoanStatus.Closed)
             })
           })
+
+          describe('V3', () => {
+            let helpers: LoanHelpersReturn
+            it('creates a loan from v1 and v2 Ids', async () => {
+              const borrower = await getNamedSigner('borrower')
+              const { nfts, getHelpers } = await takeOutLoanWithNfts(hre, {
+                amount: 100,
+                lendToken: market.lendingToken,
+                borrower,
+                version: 3,
+              })
+              helpers = await getHelpers()
+              helpers.details.loan.should.exist
+
+              // get loanStatus from helpers and check if it's equal to 2, which means it's active
+              const loanStatus = helpers.details.loan.status
+              loanStatus.should.equal(2, 'Loan is not active')
+
+              // get loan NFTs from our loan
+              const loanNFTs = await diamond.getLoanNFTs(
+                helpers.details.loan.id
+              )
+              const loanNFTsV2 = await diamond.getLoanNFTsV2(
+                helpers.details.loan.id
+              )
+              // check if loan NFTs are equal to each other
+              loanNFTs.should.eql(nfts.v1, 'Staked NFTs do not match')
+              loanNFTsV2.loanNFTs_.should.eql(
+                nfts.v2.ids,
+                'Staked NFT IDs do not match'
+              )
+              loanNFTsV2.amounts_.should.eql(
+                nfts.v2.balances,
+                'Staked NFT balances do not match'
+              )
+            })
+          })
         }
 
         describe('V2', () => {
@@ -419,40 +456,6 @@ describe('Loans', () => {
             totalOwedAfterRepay.should.eql(0)
 
             expect(loanData.status).to.equal(LoanStatus.Closed)
-          })
-        })
-        describe('V3', () => {
-          let helpers: LoanHelpersReturn
-          it('creates a loan from v1 and v2 Ids', async () => {
-            const borrower = await getNamedSigner('borrower')
-            const { nfts, getHelpers } = await takeOutLoanWithNfts(hre, {
-              amount: 100,
-              lendToken: market.lendingToken,
-              borrower,
-              version: 3,
-            })
-            helpers = await getHelpers()
-            helpers.details.loan.should.exist
-
-            // get loanStatus from helpers and check if it's equal to 2, which means it's active
-            const loanStatus = helpers.details.loan.status
-            loanStatus.should.equal(2, 'Loan is not active')
-
-            // get loan NFTs from our loan
-            const loanNFTs = await diamond.getLoanNFTs(helpers.details.loan.id)
-            const loanNFTsV2 = await diamond.getLoanNFTsV2(
-              helpers.details.loan.id
-            )
-            // check if loan NFTs are equal to each other
-            loanNFTs.should.eql(nfts.v1, 'Staked NFTs do not match')
-            loanNFTsV2.loanNFTs_.should.eql(
-              nfts.v2.ids,
-              'Staked NFT IDs do not match'
-            )
-            loanNFTsV2.amounts_.should.eql(
-              nfts.v2.balances,
-              'Staked NFT balances do not match'
-            )
           })
         })
       })

--- a/test/integration/loans.test.ts
+++ b/test/integration/loans.test.ts
@@ -1,4 +1,5 @@
 import chai, { expect } from 'chai'
+import { Console } from 'console'
 import { solidity } from 'ethereum-waffle'
 import { BigNumber, Signer } from 'ethers'
 import hre from 'hardhat'
@@ -135,7 +136,7 @@ describe('Loans', () => {
         // })
       })
 
-      describe('with NFT', () => {
+      describe.only('with NFT', () => {
         beforeEach(async () => {
           await hre.deployments.fixture('protocol', {
             keepExistingDeployments: true,
@@ -166,6 +167,8 @@ describe('Loans', () => {
               })
               helpers = await getHelpers()
 
+              console.log('loan id')
+              console.log(helpers.details.loan.id)
               helpers.details.loan.should.exist
 
               // get loanStatus from helpers and check if it's equal to 2, which means it's active
@@ -175,6 +178,7 @@ describe('Loans', () => {
               const loanNFTs = await diamond.getLoanNFTs(
                 helpers.details.loan.id
               )
+              console.log(loanNFTs)
               loanNFTs.should.eql(nfts.v1, 'Staked NFTs do not match')
             })
 
@@ -314,6 +318,8 @@ describe('Loans', () => {
             })
             helpers = await getHelpers()
 
+            console.log('loan id')
+            console.log(helpers.details.loan.id)
             helpers.details.loan.should.exist
 
             const loanStatus = helpers.details.loan.status
@@ -322,7 +328,7 @@ describe('Loans', () => {
             const loanNFTsV2 = await diamond.getLoanNFTsV2(
               helpers.details.loan.id
             )
-
+            console.log(loanNFTsV2)
             loanNFTsV2.loanNFTs_.should.eql(
               nfts.v2.ids,
               'Staked NFT IDs do not match'
@@ -428,19 +434,31 @@ describe('Loans', () => {
               amount: 100,
               lendToken: market.lendingToken,
               borrower,
-              version: 2,
+              version: 3,
             })
+            console.log('NFTs used')
+            console.log(nfts)
             helpers = await getHelpers()
             helpers.details.loan.should.exist
+            console.log('loan id')
+            console.log(helpers.details.loan.id)
 
             // get loanStatus from helpers and check if it's equal to 2, which means it's active
             const loanStatus = helpers.details.loan.status
             loanStatus.should.equal(2, 'Loan is not active')
 
+            // get loan NFTs from our loan
+            const loanNFTs = await diamond.getLoanNFTs(helpers.details.loan.id)
             const loanNFTsV2 = await diamond.getLoanNFTsV2(
               helpers.details.loan.id
             )
+            console.log('loan nfts v1 ')
+            console.log(loanNFTs)
+            console.log('loan nfts v2')
+            console.log(loanNFTsV2)
 
+            // check if loan NFTs are equal to each other
+            loanNFTs.should.eql(nfts.v1, 'Staked NFTs do not match')
             loanNFTsV2.loanNFTs_.should.eql(
               nfts.v2.ids,
               'Staked NFT IDs do not match'

--- a/test/integration/loans.test.ts
+++ b/test/integration/loans.test.ts
@@ -431,7 +431,6 @@ describe('Loans', () => {
               version: 2,
             })
             helpers = await getHelpers()
-            console.log(helpers)
             helpers.details.loan.should.exist
 
             // get loanStatus from helpers and check if it's equal to 2, which means it's active

--- a/test/integration/loans.test.ts
+++ b/test/integration/loans.test.ts
@@ -420,6 +420,38 @@ describe('Loans', () => {
             expect(loanData.status).to.equal(LoanStatus.Closed)
           })
         })
+        describe('V3', () => {
+          let helpers: LoanHelpersReturn
+          it('creates a loan from v1 and v2 Ids', async () => {
+            const borrower = await getNamedSigner('borrower')
+            const { nfts, getHelpers } = await takeOutLoanWithNfts(hre, {
+              amount: 100,
+              lendToken: market.lendingToken,
+              borrower,
+              version: 2,
+            })
+            helpers = await getHelpers()
+            console.log(helpers)
+            helpers.details.loan.should.exist
+
+            // get loanStatus from helpers and check if it's equal to 2, which means it's active
+            const loanStatus = helpers.details.loan.status
+            loanStatus.should.equal(2, 'Loan is not active')
+
+            const loanNFTsV2 = await diamond.getLoanNFTsV2(
+              helpers.details.loan.id
+            )
+
+            loanNFTsV2.loanNFTs_.should.eql(
+              nfts.v2.ids,
+              'Staked NFT IDs do not match'
+            )
+            loanNFTsV2.amounts_.should.eql(
+              nfts.v2.balances,
+              'Staked NFT balances do not match'
+            )
+          })
+        })
       })
     })
   }

--- a/test/integration/loans.test.ts
+++ b/test/integration/loans.test.ts
@@ -136,7 +136,7 @@ describe('Loans', () => {
         // })
       })
 
-      describe.only('with NFT', () => {
+      describe('with NFT', () => {
         beforeEach(async () => {
           await hre.deployments.fixture('protocol', {
             keepExistingDeployments: true,
@@ -167,8 +167,6 @@ describe('Loans', () => {
               })
               helpers = await getHelpers()
 
-              console.log('loan id')
-              console.log(helpers.details.loan.id)
               helpers.details.loan.should.exist
 
               // get loanStatus from helpers and check if it's equal to 2, which means it's active
@@ -178,7 +176,6 @@ describe('Loans', () => {
               const loanNFTs = await diamond.getLoanNFTs(
                 helpers.details.loan.id
               )
-              console.log(loanNFTs)
               loanNFTs.should.eql(nfts.v1, 'Staked NFTs do not match')
             })
 
@@ -318,8 +315,6 @@ describe('Loans', () => {
             })
             helpers = await getHelpers()
 
-            console.log('loan id')
-            console.log(helpers.details.loan.id)
             helpers.details.loan.should.exist
 
             const loanStatus = helpers.details.loan.status
@@ -328,7 +323,7 @@ describe('Loans', () => {
             const loanNFTsV2 = await diamond.getLoanNFTsV2(
               helpers.details.loan.id
             )
-            console.log(loanNFTsV2)
+
             loanNFTsV2.loanNFTs_.should.eql(
               nfts.v2.ids,
               'Staked NFT IDs do not match'
@@ -436,12 +431,8 @@ describe('Loans', () => {
               borrower,
               version: 3,
             })
-            console.log('NFTs used')
-            console.log(nfts)
             helpers = await getHelpers()
             helpers.details.loan.should.exist
-            console.log('loan id')
-            console.log(helpers.details.loan.id)
 
             // get loanStatus from helpers and check if it's equal to 2, which means it's active
             const loanStatus = helpers.details.loan.status
@@ -452,11 +443,6 @@ describe('Loans', () => {
             const loanNFTsV2 = await diamond.getLoanNFTsV2(
               helpers.details.loan.id
             )
-            console.log('loan nfts v1 ')
-            console.log(loanNFTs)
-            console.log('loan nfts v2')
-            console.log(loanNFTsV2)
-
             // check if loan NFTs are equal to each other
             loanNFTs.should.eql(nfts.v1, 'Staked NFTs do not match')
             loanNFTsV2.loanNFTs_.should.eql(


### PR DESCRIPTION
Given that the user has a combination of V1 and V2 tokens, we need to combine both NFT ID types to take out a loan. It doesn't make sense for a user to discriminate between a V1 and a V2 token when they are just trying to take out a loan.

An extra version # has been added in the `CreateLoanWithNFTFacet.sol` and the `MainnetCreateLoanWithNFTFacet.sol`. A new test has also been added in the `loans.test.ts` and the helper function for `takeOutLoanWithNFTs` is updated with the new `case: 3`