### PR TITLE
Only call initNFTBridge on mainnet

### DIFF
--- a/config/index.ts
+++ b/config/index.ts
@@ -30,10 +30,15 @@ import { tokens } from './tokens'
  * @param network HardhatRuntimeEnvironment Network object
  * @return boolean
  */
-export const isEtheremNetwork = (network: Network): boolean =>
-  ['mainnet', 'kovan', 'rinkeby', 'ropsten'].some(
-    (n) => n === getNetworkName(network)
-  )
+export const isEtheremNetwork = (
+  network: Network,
+  isMainnet = false
+): boolean =>
+  isMainnet
+    ? getNetworkName(network) === 'mainnet'
+    : ['mainnet', 'kovan', 'rinkeby', 'ropsten'].some(
+        (n) => n === getNetworkName(network)
+      )
 
 export const getNetworkName = (network: Network): string =>
   process.env.FORKING_NETWORK ?? network.name

--- a/deploy/protocol.ts
+++ b/deploy/protocol.ts
@@ -227,7 +227,7 @@ const deployProtocol: DeployFunction = async (hre) => {
   const ERC1155_PREDICATE = `0x0B9020d4E32990D67559b1317c7BF0C15D6EB88f`
   // set approval for all tokens to be transfered by ERC1155 Predicate
   if (
-    isEtheremNetwork(network) &&
+    isEtheremNetwork(network, true) &&
     nftV2.isApprovedForAll(diamond.address, ERC1155_PREDICATE)
   ) {
     await diamond.initNFTBridge()


### PR DESCRIPTION
Since we can only bridge on Mainnet, only call the init function for the diamond to approve the bridge predicate contracts