### PR TITLE
[PROTOCOL-1202] Chainlinkn use latestRoundData instead of latestAnswer

### DIFF
--- a/contracts/price-aggregator/pricers/ChainlinkPricer.sol
+++ b/contracts/price-aggregator/pricers/ChainlinkPricer.sol
@@ -40,7 +40,7 @@ contract ChainlinkPricer {
         ) = ChainlinkAgg(getEthAggregator(token)).latestRoundData();
         require(rawPrice > 0, "Chainlink price <= 0");
         require(updateTime != 0, "Incomplete round");
-        require(answeredInRound >= roundID, "Stale price");
+        require(answeredInRound + 2 >= roundID, "Stale price");
         price_ = SafeCast.toUint256(rawPrice);
     }
 

--- a/contracts/price-aggregator/pricers/ChainlinkPricer.sol
+++ b/contracts/price-aggregator/pricers/ChainlinkPricer.sol
@@ -31,9 +31,17 @@ contract ChainlinkPricer {
     }
 
     function getEthPrice(address token) external view returns (uint256 price_) {
-        price_ = SafeCast.toUint256(
-            ChainlinkAgg(getEthAggregator(token)).latestAnswer()
-        );
+        (
+            uint80 roundID,
+            int256 rawPrice,
+            uint256 startedAt,
+            uint256 updateTime,
+            uint80 answeredInRound
+        ) = ChainlinkAgg(getEthAggregator(token)).latestRoundData();
+        require(rawPrice > 0, "Chainlink price <= 0");
+        require(updateTime != 0, "Incomplete round");
+        require(answeredInRound >= roundID, "Stale price");
+        price_ = SafeCast.toUint256(rawPrice);
     }
 
     function getEthAggregator(address token) public view returns (address) {


### PR DESCRIPTION
It is:
- Replacing latestAnswer with latestRoundData for the freshest data
- Added extra validations